### PR TITLE
Update internal.cpp

### DIFF
--- a/src/natives/internal.cpp
+++ b/src/natives/internal.cpp
@@ -29,9 +29,9 @@ cell AMX_NATIVE_CALL Natives::Streamer_CallbackHook(AMX *amx, cell *params)
 		case STREAMER_OPC:
 		{
 			CHECK_PARAMS(2, "Streamer_CallbackHook");
-			cell *playerid = NULL;
-			amx_GetAddr(amx, params[2], &playerid);
-			return static_cast<cell>(core->getCallbacks()->OnPlayerConnect(static_cast<int>(*playerid)));
+			//cell *playerid = NULL;
+			//amx_GetAddr(amx, params[2], &playerid);
+			return static_cast<cell>(core->getCallbacks()->OnPlayerConnect(static_cast<int>(params[2])));
 		}
 		case STREAMER_OPDC:
 		{


### PR DESCRIPTION
This fixes crash with sampGDK InvokeNative and comments useless parts.
