### PR TITLE
AttachDynamicObjectToObject

### DIFF
--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -471,7 +471,7 @@ void Streamer::processObjects(Player &player, const std::vector<SharedCell> &cel
 				{
 					if (o->second->attach)
 					{
-						distance = static_cast<float>(boost::geometry::comparable_distance(player.position, o->second->attach->position));
+						distance = static_cast<float>(boost::geometry::comparable_distance(player.position, o->second->attach->position)) + 0.01f;
 					}
 					else
 					{


### PR DESCRIPTION
There is an issue with objects attached to objects, when I tested the function, objects were created without issues, but they weren't being attached at all. After adding some debug messages, I found out that the attachments were being streamed before the base object, so when attempting to attach them it would fail silently because it wasn't able to find the base object in the *internalObjects* map.

This small commit adds a small offset (0.01) to the distance that is used as key when adding them to *discoveredObjects*, so they get processed AFTER the base object.

***Related:*** *#46 #47*