### PR TITLE
Include guard

### DIFF
--- a/streamer.inc
+++ b/streamer.inc
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if defined _inc_streamer
+	#endinput
+#endif
+#define _inc_streamer
 
 #include <a_samp>
 


### PR DESCRIPTION
For us using Zeex's compiler lack of include forces us to update .inc manually with every update. This fixes that