### PR TITLE
Reliability improvements for definitions

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -17,7 +17,7 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#define INVALID_ALTERNATE_ID (-1)
+#define INVALID_PICKUP_ID (-1)
 #define INVALID_STREAMER_ID (0)
 
 #define STREAMER_MAX_TYPES (8)

--- a/src/common.h
+++ b/src/common.h
@@ -18,7 +18,6 @@
 #define COMMON_H
 
 #define INVALID_ALTERNATE_ID (-1)
-#define INVALID_GENERIC_ID (0xFFFF)
 #define INVALID_STREAMER_ID (0)
 
 #define STREAMER_MAX_TYPES (8)

--- a/src/manipulation/float.cpp
+++ b/src/manipulation/float.cpp
@@ -1013,7 +1013,7 @@ int Manipulation::setFloatData(AMX *amx, cell *params)
 							i->second = sampgdk::CreatePlayerObject(p->first, o->second->modelID, o->second->position[0], o->second->position[1], o->second->position[2], o->second->rotation[0], o->second->rotation[1], o->second->rotation[2], o->second->drawDistance);
 							if (o->second->attach)
 							{
-								if (o->second->attach->object != INVALID_GENERIC_ID)
+								if (o->second->attach->object != INVALID_OBJECT_ID)
 								{
 									boost::unordered_map<int, int>::iterator j = p->second.internalObjects.find(o->second->attach->object);
 									if (j != p->second.internalObjects.end())
@@ -1025,7 +1025,7 @@ int Manipulation::setFloatData(AMX *amx, cell *params)
 										}
 									}
 								}
-								else if (o->second->attach->player != INVALID_GENERIC_ID)
+								else if (o->second->attach->player != INVALID_PLAYER_ID)
 								{
 									AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 									if (native != NULL)
@@ -1033,7 +1033,7 @@ int Manipulation::setFloatData(AMX *amx, cell *params)
 										sampgdk::InvokeNative(native, "dddffffffd", p->first, i->second, o->second->attach->player, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], 1);
 									}
 								}
-								else if (o->second->attach->vehicle != INVALID_GENERIC_ID)
+								else if (o->second->attach->vehicle != INVALID_VEHICLE_ID)
 								{
 									sampgdk::AttachPlayerObjectToVehicle(p->first, i->second, o->second->attach->vehicle, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2]);
 								}
@@ -1457,7 +1457,7 @@ int Manipulation::setFloatData(AMX *amx, cell *params)
 						if (i != p->second.internalTextLabels.end())
 						{
 							sampgdk::DeletePlayer3DTextLabel(p->first, i->second);
-							i->second = sampgdk::CreatePlayer3DTextLabel(p->first, t->second->text.c_str(), t->second->color, t->second->position[0], t->second->position[1], t->second->position[2], t->second->drawDistance, t->second->attach ? t->second->attach->player : INVALID_GENERIC_ID, t->second->attach ? t->second->attach->vehicle : INVALID_GENERIC_ID, t->second->testLOS);
+							i->second = sampgdk::CreatePlayer3DTextLabel(p->first, t->second->text.c_str(), t->second->color, t->second->position[0], t->second->position[1], t->second->position[2], t->second->drawDistance, t->second->attach ? t->second->attach->player : INVALID_PLAYER_ID, t->second->attach ? t->second->attach->vehicle : INVALID_VEHICLE_ID, t->second->testLOS);
 						}
 					}
 				}

--- a/src/manipulation/int.cpp
+++ b/src/manipulation/int.cpp
@@ -63,7 +63,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 						{
 							return o->second->attach->player;
 						}
-						return INVALID_GENERIC_ID;
+						return INVALID_PLAYER_ID;
 					}
 					case AttachedVehicle:
 					{
@@ -71,7 +71,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 						{
 							return o->second->attach->vehicle;
 						}
-						return INVALID_GENERIC_ID;
+						return INVALID_VEHICLE_ID;
 					}
 					case ExtraID:
 					{
@@ -338,7 +338,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 						{
 							return t->second->attach->player;
 						}
-						return INVALID_GENERIC_ID;
+						return INVALID_PLAYER_ID;
 					}
 					case AttachedVehicle:
 					{
@@ -346,7 +346,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 						{
 							return t->second->attach->vehicle;
 						}
-						return INVALID_GENERIC_ID;
+						return INVALID_VEHICLE_ID;
 					}
 					case Color:
 					{
@@ -410,7 +410,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 						{
 							return a->second->attach->player;
 						}
-						return INVALID_GENERIC_ID;
+						return INVALID_PLAYER_ID;
 					}
 					case AttachedVehicle:
 					{
@@ -418,7 +418,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 						{
 							return a->second->attach->vehicle;
 						}
-						return INVALID_GENERIC_ID;
+						return INVALID_VEHICLE_ID;
 					}
 					case ExtraID:
 					{
@@ -568,8 +568,8 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 								return 0;
 							}
 							o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
-							o->second->attach->player = INVALID_GENERIC_ID;
-							o->second->attach->vehicle = INVALID_GENERIC_ID;
+							o->second->attach->player = INVALID_PLAYER_ID;
+							o->second->attach->vehicle = INVALID_VEHICLE_ID;
 							o->second->attach->object = static_cast<int>(params[4]);
 							o->second->attach->positionOffset.setZero();
 							o->second->attach->rotation.setZero();
@@ -594,7 +594,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					case AttachedPlayer:
 					{
-						if (static_cast<int>(params[4]) != INVALID_GENERIC_ID)
+						if (static_cast<int>(params[4]) != INVALID_PLAYER_ID)
 						{
 							if (o->second->move)
 							{
@@ -608,7 +608,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 							}
 							o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
 							o->second->attach->object = INVALID_STREAMER_ID;
-							o->second->attach->vehicle = INVALID_GENERIC_ID;
+							o->second->attach->vehicle = INVALID_VEHICLE_ID;
 							o->second->attach->player = static_cast<int>(params[4]);
 							o->second->attach->positionOffset.setZero();
 							o->second->attach->rotation.setZero();
@@ -619,7 +619,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						{
 							if (o->second->attach)
 							{
-								if (o->second->attach->player != INVALID_GENERIC_ID)
+								if (o->second->attach->player != INVALID_PLAYER_ID)
 								{
 									o->second->attach.reset();
 									core->getStreamer()->attachedObjects.erase(o->second);
@@ -632,7 +632,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					case AttachedVehicle:
 					{
-						if (static_cast<int>(params[4]) != INVALID_GENERIC_ID)
+						if (static_cast<int>(params[4]) != INVALID_VEHICLE_ID)
 						{
 							if (o->second->move)
 							{
@@ -641,7 +641,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 							}
 							o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
 							o->second->attach->object = INVALID_STREAMER_ID;
-							o->second->attach->player = INVALID_GENERIC_ID;
+							o->second->attach->player = INVALID_PLAYER_ID;
 							o->second->attach->vehicle = static_cast<int>(params[4]);
 							o->second->attach->positionOffset.setZero();
 							o->second->attach->rotation.setZero();
@@ -652,7 +652,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						{
 							if (o->second->attach)
 							{
-								if (o->second->attach->vehicle != INVALID_GENERIC_ID)
+								if (o->second->attach->vehicle != INVALID_VEHICLE_ID)
 								{
 									o->second->attach.reset();
 									core->getStreamer()->attachedObjects.erase(o->second);
@@ -690,7 +690,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					{
 						if (o->second->attach)
 						{
-							if (o->second->attach->object != INVALID_GENERIC_ID)
+							if (o->second->attach->object != INVALID_OBJECT_ID)
 							{
 								o->second->attach->syncRotation = static_cast<int>(params[4]) != 0;
 								update = true;
@@ -731,7 +731,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 										}
 									}
 								}
-								else if (o->second->attach->player != INVALID_GENERIC_ID)
+								else if (o->second->attach->player != INVALID_PLAYER_ID)
 								{
 									AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 									if (native != NULL)
@@ -739,7 +739,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 										sampgdk::InvokeNative(native, "dddffffffd", p->first, i->second, o->second->attach->player, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], 1);
 									}
 								}
-								else if (o->second->attach->vehicle != INVALID_GENERIC_ID)
+								else if (o->second->attach->vehicle != INVALID_VEHICLE_ID)
 								{
 									sampgdk::AttachPlayerObjectToVehicle(p->first, i->second, o->second->attach->vehicle, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2]);
 								}
@@ -1040,11 +1040,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					case AttachedPlayer:
 					{
-						if (static_cast<int>(params[4]) != INVALID_GENERIC_ID)
+						if (static_cast<int>(params[4]) != INVALID_PLAYER_ID)
 						{
 							t->second->attach = boost::intrusive_ptr<Item::TextLabel::Attach>(new Item::TextLabel::Attach);
 							t->second->attach->player = static_cast<int>(params[4]);
-							t->second->attach->vehicle = INVALID_GENERIC_ID;
+							t->second->attach->vehicle = INVALID_VEHICLE_ID;
 							core->getStreamer()->attachedTextLabels.insert(t->second);
 							update = true;
 						}
@@ -1052,7 +1052,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						{
 							if (t->second->attach)
 							{
-								if (t->second->attach->player != INVALID_GENERIC_ID)
+								if (t->second->attach->player != INVALID_PLAYER_ID)
 								{
 									t->second->attach.reset();
 									core->getStreamer()->attachedTextLabels.erase(t->second);
@@ -1065,10 +1065,10 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					case AttachedVehicle:
 					{
-						if (static_cast<int>(params[4]) != INVALID_GENERIC_ID)
+						if (static_cast<int>(params[4]) != INVALID_VEHICLE_ID)
 						{
 							t->second->attach = boost::intrusive_ptr<Item::TextLabel::Attach>(new Item::TextLabel::Attach);
-							t->second->attach->player = INVALID_GENERIC_ID;
+							t->second->attach->player = INVALID_PLAYER_ID;
 							t->second->attach->vehicle = static_cast<int>(params[4]);
 							core->getStreamer()->attachedTextLabels.insert(t->second);
 							update = true;
@@ -1077,7 +1077,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						{
 							if (t->second->attach)
 							{
-								if (t->second->attach->vehicle != INVALID_GENERIC_ID)
+								if (t->second->attach->vehicle != INVALID_VEHICLE_ID)
 								{
 									t->second->attach.reset();
 									core->getStreamer()->attachedTextLabels.erase(t->second);
@@ -1142,7 +1142,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						if (i != p->second.internalTextLabels.end())
 						{
 							sampgdk::DeletePlayer3DTextLabel(p->first, i->second);
-							i->second = sampgdk::CreatePlayer3DTextLabel(p->first, t->second->text.c_str(), t->second->color, t->second->position[0], t->second->position[1], t->second->position[2], t->second->drawDistance, t->second->attach ? t->second->attach->player : INVALID_GENERIC_ID, t->second->attach ? t->second->attach->vehicle : INVALID_GENERIC_ID, t->second->testLOS);
+							i->second = sampgdk::CreatePlayer3DTextLabel(p->first, t->second->text.c_str(), t->second->color, t->second->position[0], t->second->position[1], t->second->position[2], t->second->drawDistance, t->second->attach ? t->second->attach->player : INVALID_PLAYER_ID, t->second->attach ? t->second->attach->vehicle : INVALID_VEHICLE_ID, t->second->testLOS);
 						}
 					}
 				}
@@ -1168,11 +1168,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					case AttachedPlayer:
 					{
-						if (static_cast<int>(params[4]) != INVALID_GENERIC_ID)
+						if (static_cast<int>(params[4]) != INVALID_PLAYER_ID)
 						{
 							a->second->attach = boost::intrusive_ptr<Item::Area::Attach>(new Item::Area::Attach);
 							a->second->attach->object = boost::make_tuple(INVALID_STREAMER_ID, STREAMER_OBJECT_TYPE_DYNAMIC, INVALID_PLAYER_ID);
-							a->second->attach->vehicle = INVALID_GENERIC_ID;
+							a->second->attach->vehicle = INVALID_VEHICLE_ID;
 							a->second->attach->position = a->second->position;
 							a->second->attach->player = static_cast<int>(params[4]);
 							core->getStreamer()->attachedAreas.insert(a->second);
@@ -1182,7 +1182,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						{
 							if (a->second->attach)
 							{
-								if (a->second->attach->player != INVALID_GENERIC_ID)
+								if (a->second->attach->player != INVALID_PLAYER_ID)
 								{
 									a->second->attach.reset();
 									core->getStreamer()->attachedAreas.erase(a->second);
@@ -1195,11 +1195,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					case AttachedVehicle:
 					{
-						if (static_cast<int>(params[4]) != INVALID_GENERIC_ID)
+						if (static_cast<int>(params[4]) != INVALID_VEHICLE_ID)
 						{
 							a->second->attach = boost::intrusive_ptr<Item::Area::Attach>(new Item::Area::Attach);
 							a->second->attach->object = boost::make_tuple(INVALID_STREAMER_ID, STREAMER_OBJECT_TYPE_DYNAMIC, INVALID_PLAYER_ID);
-							a->second->attach->player = INVALID_GENERIC_ID;
+							a->second->attach->player = INVALID_PLAYER_ID;
 							a->second->attach->position = a->second->position;
 							a->second->attach->vehicle = static_cast<int>(params[4]);
 							core->getStreamer()->attachedAreas.insert(a->second);
@@ -1209,7 +1209,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						{
 							if (a->second->attach)
 							{
-								if (a->second->attach->vehicle != INVALID_GENERIC_ID)
+								if (a->second->attach->vehicle != INVALID_VEHICLE_ID)
 								{
 									a->second->attach.reset();
 									core->getStreamer()->attachedAreas.erase(a->second);

--- a/src/natives/actors.cpp
+++ b/src/natives/actors.cpp
@@ -318,11 +318,14 @@ cell AMX_NATIVE_CALL Natives::GetPlayerTargetDynamicActor(AMX *amx, cell *params
 	if (p != core->getData()->players.end())
 	{
 		int actorid = sampgdk::GetPlayerTargetActor(p->second.playerID);
-		for (boost::unordered_map<int, int>::iterator i = core->getData()->internalActors.begin(); i != core->getData()->internalActors.end(); ++i)
+		if(actorid != INVALID_ACTOR_ID)
 		{
-			if (i->second == actorid)
+			for (boost::unordered_map<int, int>::iterator i = core->getData()->internalActors.begin(); i != core->getData()->internalActors.end(); ++i)
 			{
-				return i->first;
+				if (i->second == actorid)
+				{
+					return i->first;
+				}
 			}
 		}
 	}

--- a/src/natives/actors.cpp
+++ b/src/natives/actors.cpp
@@ -318,13 +318,15 @@ cell AMX_NATIVE_CALL Natives::GetPlayerTargetDynamicActor(AMX *amx, cell *params
 	if (p != core->getData()->players.end())
 	{
 		int actorid = sampgdk::GetPlayerTargetActor(p->second.playerID);
-		for (boost::unordered_map<int, int>::iterator i = core->getData()->internalActors.begin(); i != core->getData()->internalActors.end(); ++i) {
-			if (i->second == actorid) {
+		for (boost::unordered_map<int, int>::iterator i = core->getData()->internalActors.begin(); i != core->getData()->internalActors.end(); ++i)
+		{
+			if (i->second == actorid)
+			{
 				return i->first;
 			}
 		}
 	}
-	return 0;
+	return INVALID_STREAMER_ID;
 }
 
 cell AMX_NATIVE_CALL Natives::GetPlayerCameraTargetDynActor(AMX *amx, cell *params)
@@ -345,5 +347,5 @@ cell AMX_NATIVE_CALL Natives::GetPlayerCameraTargetDynActor(AMX *amx, cell *para
 			}
 		}
 	}
-	return 0;
+	return INVALID_STREAMER_ID;
 }

--- a/src/natives/areas.cpp
+++ b/src/natives/areas.cpp
@@ -642,11 +642,11 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicAreaToObject(AMX *amx, cell *params)
 	boost::unordered_map<int, Item::SharedArea>::iterator a = core->getData()->areas.find(static_cast<int>(params[1]));
 	if (a != core->getData()->areas.end())
 	{
-		if ((static_cast<int>(params[2]) != INVALID_GENERIC_ID && static_cast<int>(params[3]) != STREAMER_OBJECT_TYPE_DYNAMIC) || (static_cast<int>(params[2]) != INVALID_STREAMER_ID && static_cast<int>(params[3]) == STREAMER_OBJECT_TYPE_DYNAMIC))
+		if ((static_cast<int>(params[2]) != INVALID_OBJECT_ID && static_cast<int>(params[3]) != STREAMER_OBJECT_TYPE_DYNAMIC) || (static_cast<int>(params[2]) != INVALID_STREAMER_ID && static_cast<int>(params[3]) == STREAMER_OBJECT_TYPE_DYNAMIC))
 		{
 			a->second->attach = boost::intrusive_ptr<Item::Area::Attach>(new Item::Area::Attach);
-			a->second->attach->player = INVALID_GENERIC_ID;
-			a->second->attach->vehicle = INVALID_GENERIC_ID;
+			a->second->attach->player = INVALID_PLAYER_ID;
+			a->second->attach->vehicle = INVALID_VEHICLE_ID;
 			a->second->attach->position = a->second->position;
 			a->second->attach->object = boost::make_tuple(static_cast<int>(params[2]), static_cast<int>(params[3]), static_cast<int>(params[4]));
 			a->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[5]), amx_ctof(params[6]), amx_ctof(params[7]));
@@ -656,7 +656,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicAreaToObject(AMX *amx, cell *params)
 		{
 			if (a->second->attach)
 			{
-				if ((a->second->attach->object.get<0>() != INVALID_GENERIC_ID && a->second->attach->object.get<1>() != STREAMER_OBJECT_TYPE_DYNAMIC) || (a->second->attach->object.get<0>() != INVALID_STREAMER_ID && a->second->attach->object.get<1>() == STREAMER_OBJECT_TYPE_DYNAMIC))
+				if ((a->second->attach->object.get<0>() != INVALID_OBJECT_ID && a->second->attach->object.get<1>() != STREAMER_OBJECT_TYPE_DYNAMIC) || (a->second->attach->object.get<0>() != INVALID_STREAMER_ID && a->second->attach->object.get<1>() == STREAMER_OBJECT_TYPE_DYNAMIC))
 				{
 					a->second->attach.reset();
 					core->getStreamer()->attachedAreas.erase(a->second);
@@ -675,11 +675,11 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicAreaToPlayer(AMX *amx, cell *params)
 	boost::unordered_map<int, Item::SharedArea>::iterator a = core->getData()->areas.find(static_cast<int>(params[1]));
 	if (a != core->getData()->areas.end())
 	{
-		if (static_cast<int>(params[2]) != INVALID_GENERIC_ID)
+		if (static_cast<int>(params[2]) != INVALID_PLAYER_ID)
 		{
 			a->second->attach = boost::intrusive_ptr<Item::Area::Attach>(new Item::Area::Attach);
 			a->second->attach->object = boost::make_tuple(INVALID_STREAMER_ID, STREAMER_OBJECT_TYPE_DYNAMIC, INVALID_PLAYER_ID);
-			a->second->attach->vehicle = INVALID_GENERIC_ID;
+			a->second->attach->vehicle = INVALID_VEHICLE_ID;
 			a->second->attach->position = a->second->position;
 			a->second->attach->player = static_cast<int>(params[2]);
 			a->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
@@ -689,7 +689,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicAreaToPlayer(AMX *amx, cell *params)
 		{
 			if (a->second->attach)
 			{
-				if (a->second->attach->player != INVALID_GENERIC_ID)
+				if (a->second->attach->player != INVALID_PLAYER_ID)
 				{
 					a->second->attach.reset();
 					core->getStreamer()->attachedAreas.erase(a->second);
@@ -708,11 +708,11 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicAreaToVehicle(AMX *amx, cell *params)
 	boost::unordered_map<int, Item::SharedArea>::iterator a = core->getData()->areas.find(static_cast<int>(params[1]));
 	if (a != core->getData()->areas.end())
 	{
-		if (static_cast<int>(params[2]) != INVALID_GENERIC_ID)
+		if (static_cast<int>(params[2]) != INVALID_VEHICLE_ID)
 		{
 			a->second->attach = boost::intrusive_ptr<Item::Area::Attach>(new Item::Area::Attach);
 			a->second->attach->object = boost::make_tuple(INVALID_STREAMER_ID, STREAMER_OBJECT_TYPE_DYNAMIC, INVALID_PLAYER_ID);
-			a->second->attach->player = INVALID_GENERIC_ID;
+			a->second->attach->player = INVALID_PLAYER_ID;
 			a->second->attach->position = a->second->position;
 			a->second->attach->vehicle = static_cast<int>(params[2]);
 			a->second->attach->positionOffset = a->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
@@ -722,7 +722,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicAreaToVehicle(AMX *amx, cell *params)
 		{
 			if (a->second->attach)
 			{
-				if (a->second->attach->vehicle != INVALID_GENERIC_ID)
+				if (a->second->attach->vehicle != INVALID_VEHICLE_ID)
 				{
 					a->second->attach.reset();
 					core->getStreamer()->attachedAreas.erase(a->second);

--- a/src/natives/extended.cpp
+++ b/src/natives/extended.cpp
@@ -202,7 +202,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamic3DTextLabelEx(AMX *amx, cell *params)
 	textLabel->color = static_cast<int>(params[2]);
 	textLabel->position = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
 	textLabel->drawDistance = amx_ctof(params[6]);
-	if (static_cast<int>(params[7]) != INVALID_GENERIC_ID || static_cast<int>(params[8]) != INVALID_GENERIC_ID)
+	if (static_cast<int>(params[7]) != INVALID_PLAYER_ID || static_cast<int>(params[8]) != INVALID_VEHICLE_ID)
 	{
 		textLabel->attach = boost::intrusive_ptr<Item::TextLabel::Attach>(new Item::TextLabel::Attach);
 		textLabel->attach->player = static_cast<int>(params[7]);

--- a/src/natives/miscellaneous.cpp
+++ b/src/natives/miscellaneous.cpp
@@ -671,6 +671,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 				{
 					return static_cast<cell>(i->second);
 				}
+				return INVALID_3DTEXT_ID;
 			}
 			case STREAMER_TYPE_AREA:
 			{

--- a/src/natives/miscellaneous.cpp
+++ b/src/natives/miscellaneous.cpp
@@ -705,7 +705,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 					return i->first;
 				}
 			}
-			return 0;
+			return INVALID_STREAMER_ID;
 		}
 		case STREAMER_TYPE_ACTOR:
 		{
@@ -716,7 +716,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 					return i->first;
 				}
 			}
-			return 0;
+			return INVALID_STREAMER_ID;
 		}
 	}
 	boost::unordered_map<int, Player>::iterator p = core->getData()->players.find(static_cast<int>(params[1]));
@@ -733,7 +733,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 						return i->first;
 					}
 				}
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 			case STREAMER_TYPE_CP:
 			{
@@ -741,7 +741,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 				{
 					return 1;
 				}
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 			case STREAMER_TYPE_RACE_CP:
 			{
@@ -749,7 +749,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 				{
 					return 1;
 				}
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 			case STREAMER_TYPE_MAP_ICON:
 			{
@@ -760,7 +760,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 						return i->first;
 					}
 				}
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 			case STREAMER_TYPE_3D_TEXT_LABEL:
 			{
@@ -771,7 +771,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 						return i->first;
 					}
 				}
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 			case STREAMER_TYPE_AREA:
 			{
@@ -780,16 +780,16 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)
 				{
 					return *i;
 				}
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 			default:
 			{
 				Utility::logError("Streamer_GetItemStreamerID: Invalid type specified.");
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 		}
 	}
-	return 0;
+	return INVALID_STREAMER_ID;
 }
 
 cell AMX_NATIVE_CALL Natives::Streamer_IsItemVisible(AMX *amx, cell *params)

--- a/src/natives/miscellaneous.cpp
+++ b/src/natives/miscellaneous.cpp
@@ -613,7 +613,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 			{
 				return static_cast<cell>(i->second);
 			}
-			return 0;
+			return INVALID_PICKUP_ID;
 		}
 		case STREAMER_TYPE_ACTOR:
 		{
@@ -622,7 +622,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 			{
 				return static_cast<cell>(i->second);
 			}
-			return 0;
+			return INVALID_ACTOR_ID;
 		}
 	}
 	boost::unordered_map<int, Player>::iterator p = core->getData()->players.find(static_cast<int>(params[1]));
@@ -637,7 +637,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 				{
 					return static_cast<cell>(i->second);
 				}
-				return 0;
+				return INVALID_OBJECT_ID;
 			}
 			case STREAMER_TYPE_CP:
 			{
@@ -645,7 +645,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 				{
 					return 1;
 				}
-				return 0;
+				return -1;
 			}
 			case STREAMER_TYPE_RACE_CP:
 			{
@@ -653,7 +653,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 				{
 					return 1;
 				}
-				return 0;
+				return -1;
 			}
 			case STREAMER_TYPE_MAP_ICON:
 			{
@@ -662,7 +662,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 				{
 					return static_cast<cell>(i->second);
 				}
-				return 0;
+				return -1;
 			}
 			case STREAMER_TYPE_3D_TEXT_LABEL:
 			{
@@ -679,16 +679,16 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemInternalID(AMX *amx, cell *params)
 				{
 					return *i;
 				}
-				return 0;
+				return INVALID_STREAMER_ID;
 			}
 			default:
 			{
 				Utility::logError("Streamer_GetItemInternalID: Invalid type specified.");
-				return 0;
+				return -1;
 			}
 		}
 	}
-	return 0;
+	return -1;
 }
 
 cell AMX_NATIVE_CALL Natives::Streamer_GetItemStreamerID(AMX *amx, cell *params)

--- a/src/natives/objects.cpp
+++ b/src/natives/objects.cpp
@@ -727,5 +727,5 @@ cell AMX_NATIVE_CALL Natives::GetPlayerCameraTargetDynObject(AMX *amx, cell *par
 			}
 		}
 	}
-	return 0;
+	return INVALID_STREAMER_ID;
 }

--- a/src/natives/objects.cpp
+++ b/src/natives/objects.cpp
@@ -311,7 +311,7 @@ cell AMX_NATIVE_CALL Natives::AttachCameraToDynamicObject(AMX *amx, cell *params
 	boost::unordered_map<int, Player>::iterator p = core->getData()->players.find(static_cast<int>(params[1]));
 	if (p != core->getData()->players.end())
 	{
-		int internalID = INVALID_GENERIC_ID;
+		int internalID = INVALID_OBJECT_ID;
 		boost::unordered_map<int, int>::iterator i = p->second.internalObjects.find(static_cast<int>(params[2]));
 		if (i == p->second.internalObjects.end())
 		{
@@ -331,7 +331,7 @@ cell AMX_NATIVE_CALL Natives::AttachCameraToDynamicObject(AMX *amx, cell *params
 		{
 			internalID = i->second;
 		}
-		if (internalID != INVALID_GENERIC_ID)
+		if (internalID != INVALID_OBJECT_ID)
 		{
 			sampgdk::AttachCameraToPlayerObject(p->first, internalID);
 			return 1;
@@ -357,8 +357,8 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params
 			return 0;
 		}
 		o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
-		o->second->attach->player = INVALID_GENERIC_ID;
-		o->second->attach->vehicle = INVALID_GENERIC_ID;
+		o->second->attach->player = INVALID_PLAYER_ID;
+		o->second->attach->vehicle = INVALID_VEHICLE_ID;
 		o->second->attach->object = static_cast<int>(params[2]);
 		o->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
 		o->second->attach->rotation = Eigen::Vector3f(amx_ctof(params[6]), amx_ctof(params[7]), amx_ctof(params[8]));
@@ -436,7 +436,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToPlayer(AMX *amx, cell *params
 		}
 		o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
 		o->second->attach->object = INVALID_STREAMER_ID;
-		o->second->attach->vehicle = INVALID_GENERIC_ID;
+		o->second->attach->vehicle = INVALID_VEHICLE_ID;
 		o->second->attach->player = static_cast<int>(params[2]);
 		o->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
 		o->second->attach->rotation = Eigen::Vector3f(amx_ctof(params[6]), amx_ctof(params[7]), amx_ctof(params[8]));
@@ -463,7 +463,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToPlayer(AMX *amx, cell *params
 				}
 			}
 		}
-		if (static_cast<int>(params[2]) != INVALID_GENERIC_ID)
+		if (static_cast<int>(params[2]) != INVALID_PLAYER_ID)
 		{
 			core->getStreamer()->attachedObjects.insert(o->second);
 		}
@@ -491,7 +491,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToVehicle(AMX *amx, cell *param
 		}
 		o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
 		o->second->attach->object = INVALID_STREAMER_ID;
-		o->second->attach->player = INVALID_GENERIC_ID;
+		o->second->attach->player = INVALID_PLAYER_ID;
 		o->second->attach->vehicle = static_cast<int>(params[2]);
 		o->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
 		o->second->attach->rotation = Eigen::Vector3f(amx_ctof(params[6]), amx_ctof(params[7]), amx_ctof(params[8]));
@@ -514,7 +514,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToVehicle(AMX *amx, cell *param
 				}
 			}
 		}
-		if (static_cast<int>(params[2]) != INVALID_GENERIC_ID)
+		if (static_cast<int>(params[2]) != INVALID_VEHICLE_ID)
 		{
 			core->getStreamer()->attachedObjects.insert(o->second);
 		}
@@ -535,7 +535,7 @@ cell AMX_NATIVE_CALL Natives::EditDynamicObject(AMX *amx, cell *params)
 	boost::unordered_map<int, Player>::iterator p = core->getData()->players.find(static_cast<int>(params[1]));
 	if (p != core->getData()->players.end())
 	{
-		int internalID = INVALID_GENERIC_ID;
+		int internalID = INVALID_OBJECT_ID;
 		boost::unordered_map<int, int>::iterator i = p->second.internalObjects.find(static_cast<int>(params[2]));
 		if (i == p->second.internalObjects.end())
 		{
@@ -560,7 +560,7 @@ cell AMX_NATIVE_CALL Natives::EditDynamicObject(AMX *amx, cell *params)
 		{
 			internalID = i->second;
 		}
-		if (internalID != INVALID_GENERIC_ID)
+		if (internalID != INVALID_OBJECT_ID)
 		{
 			sampgdk::EditPlayerObject(p->first, internalID);
 			return 1;

--- a/src/natives/text-labels.cpp
+++ b/src/natives/text-labels.cpp
@@ -49,7 +49,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamic3DTextLabel(AMX *amx, cell *params)
 	textLabel->color = static_cast<int>(params[2]);
 	textLabel->position = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
 	textLabel->drawDistance = amx_ctof(params[6]);
-	if (static_cast<int>(params[7]) != INVALID_GENERIC_ID || static_cast<int>(params[8]) != INVALID_GENERIC_ID)
+	if (static_cast<int>(params[7]) != INVALID_PLAYER_ID || static_cast<int>(params[8]) != INVALID_VEHICLE_ID)
 	{
 		textLabel->attach = boost::intrusive_ptr<Item::TextLabel::Attach>(new Item::TextLabel::Attach);
 		textLabel->attach->player = static_cast<int>(params[7]);

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -738,7 +738,7 @@ void Streamer::streamActors()
 			break;
 		}
 		int internalID = sampgdk::CreateActor(i->second->modelID, i->second->position[0], i->second->position[1], i->second->position[2], i->second->rotation);
-		if (internalID == INVALID_ALTERNATE_ID)
+		if (internalID == INVALID_ACTOR_ID)
 		{
 			break;
 		}
@@ -1278,7 +1278,7 @@ void Streamer::streamPickups()
 			break;
 		}
 		int internalID = sampgdk::CreatePickup(i->second->modelID, i->second->type, i->second->position[0], i->second->position[1], i->second->position[2], i->second->worldID);
-		if (internalID == INVALID_ALTERNATE_ID)
+		if (internalID == INVALID_PICKUP_ID)
 		{
 			break;
 		}

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -1140,7 +1140,7 @@ void Streamer::streamObjects(Player &player, bool automatic)
 					break;
 				}
 				int internalID = sampgdk::CreatePlayerObject(player.playerID, d->second->modelID, d->second->position[0], d->second->position[1], d->second->position[2], d->second->rotation[0], d->second->rotation[1], d->second->rotation[2], d->second->drawDistance);
-				if (internalID == INVALID_GENERIC_ID)
+				if (internalID == INVALID_OBJECT_ID)
 				{
 					player.currentVisibleObjects = player.internalObjects.size();
 					player.discoveredObjects.clear();
@@ -1164,7 +1164,7 @@ void Streamer::streamObjects(Player &player, bool automatic)
 							}
 						}
 					}
-					else if (d->second->attach->player != INVALID_GENERIC_ID)
+					else if (d->second->attach->player != INVALID_PLAYER_ID)
 					{
 						AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 						if (native != NULL)
@@ -1172,7 +1172,7 @@ void Streamer::streamObjects(Player &player, bool automatic)
 							sampgdk::InvokeNative(native, "dddffffffd", player.playerID, internalID, d->second->attach->player, d->second->attach->positionOffset[0], d->second->attach->positionOffset[1], d->second->attach->positionOffset[2], d->second->attach->rotation[0], d->second->attach->rotation[1], d->second->attach->rotation[2], 1);
 						}
 					}
-					else if (d->second->attach->vehicle != INVALID_GENERIC_ID)
+					else if (d->second->attach->vehicle != INVALID_VEHICLE_ID)
 					{
 						sampgdk::AttachPlayerObjectToVehicle(player.playerID, internalID, d->second->attach->vehicle, d->second->attach->positionOffset[0], d->second->attach->positionOffset[1], d->second->attach->positionOffset[2], d->second->attach->rotation[0], d->second->attach->rotation[1], d->second->attach->rotation[2]);
 					}
@@ -1488,8 +1488,8 @@ void Streamer::streamTextLabels(Player &player, bool automatic)
 					player.discoveredTextLabels.clear();
 					break;
 				}
-				int internalID = sampgdk::CreatePlayer3DTextLabel(player.playerID, d->second->text.c_str(), d->second->color, d->second->position[0], d->second->position[1], d->second->position[2], d->second->drawDistance, d->second->attach ? d->second->attach->player : INVALID_GENERIC_ID, d->second->attach ? d->second->attach->vehicle : INVALID_GENERIC_ID, d->second->testLOS);
-				if (internalID == INVALID_GENERIC_ID)
+				int internalID = sampgdk::CreatePlayer3DTextLabel(player.playerID, d->second->text.c_str(), d->second->color, d->second->position[0], d->second->position[1], d->second->position[2], d->second->drawDistance, d->second->attach ? d->second->attach->player : INVALID_PLAYER_ID, d->second->attach ? d->second->attach->vehicle : INVALID_VEHICLE_ID, d->second->testLOS);
+				if (internalID == INVALID_3DTEXT_ID)
 				{
 					player.currentVisibleTextLabels = player.internalTextLabels.size();
 					player.discoveredTextLabels.clear();
@@ -1587,7 +1587,7 @@ void Streamer::processAttachedAreas()
 		if ((*a)->attach)
 		{
 			bool adjust = false;
-			if (((*a)->attach->object.get<0>() != INVALID_GENERIC_ID && (*a)->attach->object.get<1>() != STREAMER_OBJECT_TYPE_DYNAMIC) || ((*a)->attach->object.get<0>() != INVALID_STREAMER_ID && (*a)->attach->object.get<1>() == STREAMER_OBJECT_TYPE_DYNAMIC))
+			if (((*a)->attach->object.get<0>() != INVALID_OBJECT_ID && (*a)->attach->object.get<1>() != STREAMER_OBJECT_TYPE_DYNAMIC) || ((*a)->attach->object.get<0>() != INVALID_STREAMER_ID && (*a)->attach->object.get<1>() == STREAMER_OBJECT_TYPE_DYNAMIC))
 			{
 				switch ((*a)->attach->object.get<1>())
 				{
@@ -1619,7 +1619,7 @@ void Streamer::processAttachedAreas()
 					}
 				}
 			}
-			else if ((*a)->attach->player != INVALID_GENERIC_ID)
+			else if ((*a)->attach->player != INVALID_PLAYER_ID)
 			{
 				float heading = 0.0f;
 				Eigen::Vector3f position = Eigen::Vector3f::Zero();
@@ -1627,7 +1627,7 @@ void Streamer::processAttachedAreas()
 				sampgdk::GetPlayerFacingAngle((*a)->attach->player, &heading);
 				Utility::constructAttachedArea(*a, boost::variant<float, Eigen::Vector3f, Eigen::Vector4f>(heading), position);
 			}
-			else if ((*a)->attach->vehicle != INVALID_GENERIC_ID)
+			else if ((*a)->attach->vehicle != INVALID_VEHICLE_ID)
 			{
 				bool occupied = false;
 				for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
@@ -1717,11 +1717,11 @@ void Streamer::processAttachedObjects()
 					adjust = true;
 				}
 			}
-			else if ((*o)->attach->player != INVALID_GENERIC_ID)
+			else if ((*o)->attach->player != INVALID_PLAYER_ID)
 			{
 				adjust = sampgdk::GetPlayerPos((*o)->attach->player, &(*o)->attach->position[0], &(*o)->attach->position[1], &(*o)->attach->position[2]);
 			}
-			else if ((*o)->attach->vehicle != INVALID_GENERIC_ID)
+			else if ((*o)->attach->vehicle != INVALID_VEHICLE_ID)
 			{
 				adjust = sampgdk::GetVehiclePos((*o)->attach->vehicle, &(*o)->attach->position[0], &(*o)->attach->position[1], &(*o)->attach->position[2]);
 			}
@@ -1747,11 +1747,11 @@ void Streamer::processAttachedTextLabels()
 		bool adjust = false;
 		if ((*t)->attach)
 		{
-			if ((*t)->attach->player != INVALID_GENERIC_ID)
+			if ((*t)->attach->player != INVALID_PLAYER_ID)
 			{
 				adjust = sampgdk::GetPlayerPos((*t)->attach->player, &(*t)->attach->position[0], &(*t)->attach->position[1], &(*t)->attach->position[2]);
 			}
-			else if ((*t)->attach->vehicle != INVALID_GENERIC_ID)
+			else if ((*t)->attach->vehicle != INVALID_VEHICLE_ID)
 			{
 				adjust = sampgdk::GetVehiclePos((*t)->attach->vehicle, &(*t)->attach->position[0], &(*t)->attach->position[1], &(*t)->attach->position[2]);
 			}

--- a/src/utility/misc.h
+++ b/src/utility/misc.h
@@ -135,7 +135,7 @@ namespace Utility
 				}
 			}
 		}
-		return INVALID_GENERIC_ID;
+		return INVALID_PLAYER_ID;
 	}
 
 	template<typename T>


### PR DESCRIPTION
I hope that what I did for Streamer_GetItemInternalID is fine. I did those changes mainly because of [this](http://wiki.sa-mp.com/wiki/Starting_IDs):
- "0" is actually a valid pickup/actor/3D text label ID, started using the corresponding INVALID_X_ID for each one.
- "INVALID_STREAMER_ID" is correct for area ID (this makes almost no sense for me, it basically returns the same inserted ID, if I understood correctly, if the specified area actually exists, probably you did this to use all streaming types in those switches, to keep constancy), which is still 0.
- "-1" is more appropriate for invalid cases, but this return value is questionable for checkpoints and race checkpoints, but it should be fine.
- It offers now better "compatibility" with the invalid SA-MP returned IDs.