### PR TITLE
Optimisations/Fixes small mistakes

### DIFF
--- a/src/manipulation/float.cpp
+++ b/src/manipulation/float.cpp
@@ -1018,7 +1018,7 @@ int Manipulation::setFloatData(AMX *amx, cell *params)
 									boost::unordered_map<int, int>::iterator j = p->second.internalObjects.find(o->second->attach->object);
 									if (j != p->second.internalObjects.end())
 									{
-										AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
+										static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
 										if (native != NULL)
 										{
 											sampgdk::InvokeNative(native, "dddffffffb", p->first, i->second, j->second, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], o->second->attach->syncRotation);
@@ -1027,7 +1027,7 @@ int Manipulation::setFloatData(AMX *amx, cell *params)
 								}
 								else if (o->second->attach->player != INVALID_PLAYER_ID)
 								{
-									AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
+									static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 									if (native != NULL)
 									{
 										sampgdk::InvokeNative(native, "dddffffffd", p->first, i->second, o->second->attach->player, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], 1);

--- a/src/manipulation/int.cpp
+++ b/src/manipulation/int.cpp
@@ -55,7 +55,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 						{
 							return o->second->attach->object;
 						}
-						return INVALID_STREAMER_ID;
+						return INVALID_OBJECT_ID;
 					}
 					case AttachedPlayer:
 					{
@@ -97,7 +97,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (o->second->attach)
 						{
-							if (o->second->attach->object != INVALID_STREAMER_ID)
+							if (o->second->attach->object != INVALID_OBJECT_ID)
 							{
 								return o->second->attach->syncRotation != 0;
 							}
@@ -555,7 +555,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					case AttachedObject:
 					{
-						if (static_cast<int>(params[4]) != INVALID_STREAMER_ID)
+						if (static_cast<int>(params[4]) != INVALID_OBJECT_ID)
 						{
 							if (o->second->move)
 							{
@@ -581,7 +581,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 						{
 							if (o->second->attach)
 							{
-								if (o->second->attach->object != INVALID_STREAMER_ID)
+								if (o->second->attach->object != INVALID_OBJECT_ID)
 								{
 									o->second->attach.reset();
 									core->getStreamer()->attachedObjects.erase(o->second);
@@ -607,7 +607,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 								return 0;
 							}
 							o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
-							o->second->attach->object = INVALID_STREAMER_ID;
+							o->second->attach->object = INVALID_OBJECT_ID;
 							o->second->attach->vehicle = INVALID_VEHICLE_ID;
 							o->second->attach->player = static_cast<int>(params[4]);
 							o->second->attach->positionOffset.setZero();
@@ -640,7 +640,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 								return 0;
 							}
 							o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
-							o->second->attach->object = INVALID_STREAMER_ID;
+							o->second->attach->object = INVALID_OBJECT_ID;
 							o->second->attach->player = INVALID_PLAYER_ID;
 							o->second->attach->vehicle = static_cast<int>(params[4]);
 							o->second->attach->positionOffset.setZero();
@@ -719,7 +719,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 							i->second = sampgdk::CreatePlayerObject(p->first, o->second->modelID, o->second->position[0], o->second->position[1], o->second->position[2], o->second->rotation[0], o->second->rotation[1], o->second->rotation[2], o->second->drawDistance);
 							if (o->second->attach)
 							{
-								if (o->second->attach->object != INVALID_STREAMER_ID)
+								if (o->second->attach->object != INVALID_OBJECT_ID)
 								{
 									boost::unordered_map<int, int>::iterator j = p->second.internalObjects.find(o->second->attach->object);
 									if (j != p->second.internalObjects.end())

--- a/src/manipulation/int.cpp
+++ b/src/manipulation/int.cpp
@@ -562,7 +562,8 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 								Utility::logError("Streamer_SetIntData: Object is currently moving and must be stopped first.");
 								return 0;
 							}
-							if (sampgdk::FindNative("SetPlayerGravity") == NULL)
+							static AMX_NATIVE native = sampgdk::FindNative("SetPlayerGravity");
+							if (native == NULL)
 							{
 								Utility::logError("Streamer_SetIntData: YSF plugin must be loaded to attach objects to objects.");
 								return 0;
@@ -601,7 +602,8 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 								Utility::logError("Streamer_SetIntData: Object is currently moving and must be stopped first.");
 								return 0;
 							}
-							if (sampgdk::FindNative("SetPlayerGravity") == NULL)
+							static AMX_NATIVE native = sampgdk::FindNative("SetPlayerGravity");
+							if (native == NULL)
 							{
 								Utility::logError("Streamer_SetIntData: YSF plugin must be loaded to attach objects to players.");
 								return 0;
@@ -724,7 +726,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 									boost::unordered_map<int, int>::iterator j = p->second.internalObjects.find(o->second->attach->object);
 									if (j != p->second.internalObjects.end())
 									{
-										AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
+										static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
 										if (native != NULL)
 										{
 											sampgdk::InvokeNative(native, "dddffffffb", p->first, i->second, j->second, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], o->second->attach->syncRotation);
@@ -733,7 +735,7 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 								}
 								else if (o->second->attach->player != INVALID_PLAYER_ID)
 								{
-									AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
+									static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 									if (native != NULL)
 									{
 										sampgdk::InvokeNative(native, "dddffffffd", p->first, i->second, o->second->attach->player, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], 1);

--- a/src/natives/objects.cpp
+++ b/src/natives/objects.cpp
@@ -390,7 +390,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params
 				}
 			}
 		}
-		if (static_cast<int>(params[2]) != INVALID_STREAMER_ID)
+		if (static_cast<int>(params[2]) != INVALID_OBJECT_ID)
 		{
 			boost::unordered_map<int, Item::SharedObject>::iterator p = core->getData()->objects.find(static_cast<int>(params[2]));
 			if (p != core->getData()->objects.end())
@@ -435,7 +435,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToPlayer(AMX *amx, cell *params
 			return 0;
 		}
 		o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
-		o->second->attach->object = INVALID_STREAMER_ID;
+		o->second->attach->object = INVALID_OBJECT_ID;
 		o->second->attach->vehicle = INVALID_VEHICLE_ID;
 		o->second->attach->player = static_cast<int>(params[2]);
 		o->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));
@@ -490,7 +490,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToVehicle(AMX *amx, cell *param
 			return 0;
 		}
 		o->second->attach = boost::intrusive_ptr<Item::Object::Attach>(new Item::Object::Attach);
-		o->second->attach->object = INVALID_STREAMER_ID;
+		o->second->attach->object = INVALID_OBJECT_ID;
 		o->second->attach->player = INVALID_PLAYER_ID;
 		o->second->attach->vehicle = static_cast<int>(params[2]);
 		o->second->attach->positionOffset = Eigen::Vector3f(amx_ctof(params[3]), amx_ctof(params[4]), amx_ctof(params[5]));

--- a/src/natives/objects.cpp
+++ b/src/natives/objects.cpp
@@ -343,7 +343,8 @@ cell AMX_NATIVE_CALL Natives::AttachCameraToDynamicObject(AMX *amx, cell *params
 cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(9, "AttachDynamicObjectToObject");
-	if (sampgdk::FindNative("SetPlayerGravity") == NULL)
+	static AMX_NATIVE native = sampgdk::FindNative("SetPlayerGravity");
+	if (native == NULL)
 	{
 		Utility::logError("AttachDynamicObjectToObject: YSF plugin must be loaded to attach objects to objects.");
 		return 0;
@@ -371,7 +372,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params
 				boost::unordered_map<int, int>::iterator j = p->second.internalObjects.find(o->second->attach->object);
 				if (j != p->second.internalObjects.end())
 				{
-					AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
+					static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
 					if (native != NULL)
 					{
 						sampgdk::InvokeNative(native, "dddffffffb", p->first, i->second, j->second, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], o->second->attach->syncRotation);
@@ -421,7 +422,8 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params
 cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToPlayer(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(8, "AttachDynamicObjectToPlayer");
-	if (sampgdk::FindNative("SetPlayerGravity") == NULL)
+	static AMX_NATIVE native = sampgdk::FindNative("SetPlayerGravity");
+	if (native == NULL)
 	{
 		Utility::logError("AttachDynamicObjectToPlayer: YSF plugin must be loaded to attach objects to players.");
 		return 0;
@@ -445,7 +447,7 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToPlayer(AMX *amx, cell *params
 			boost::unordered_map<int, int>::iterator i = p->second.internalObjects.find(o->first);
 			if (i != p->second.internalObjects.end())
 			{
-				AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
+				static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 				if (native != NULL)
 				{
 					sampgdk::InvokeNative(native, "dddffffffd", p->first, i->second, o->second->attach->player, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], 0);

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -1152,7 +1152,7 @@ void Streamer::streamObjects(Player &player, bool automatic)
 				}
 				if (d->second->attach)
 				{
-					if (d->second->attach->object != INVALID_STREAMER_ID)
+					if (d->second->attach->object != INVALID_OBJECT_ID)
 					{
 						boost::unordered_map<int, int>::iterator i = player.internalObjects.find(d->second->attach->object);
 						if (i != player.internalObjects.end())
@@ -1708,7 +1708,7 @@ void Streamer::processAttachedObjects()
 		if ((*o)->attach)
 		{
 			bool adjust = false;
-			if ((*o)->attach->object != INVALID_STREAMER_ID)
+			if ((*o)->attach->object != INVALID_OBJECT_ID)
 			{
 				boost::unordered_map<int, Item::SharedObject>::iterator p = core->getData()->objects.find((*o)->attach->object);
 				if (p != core->getData()->objects.end())

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -759,9 +759,9 @@ void Streamer::streamActors()
 
 void Streamer::processAreas(Player &player, const std::vector<SharedCell> &cells)
 {
+	int state = sampgdk::GetPlayerState(player.playerID);
 	for (std::vector<SharedCell>::const_iterator c = cells.begin(); c != cells.end(); ++c)
 	{
-		int state = sampgdk::GetPlayerState(player.playerID);
 		for (boost::unordered_map<int, Item::SharedArea>::const_iterator a = (*c)->areas.begin(); a != (*c)->areas.end(); ++a)
 		{
 			bool inArea = false;

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -458,7 +458,7 @@ void Streamer::performPlayerUpdate(Player &player, bool automatic)
 					}
 					case STREAMER_TYPE_ACTOR:
 					{
-						if (!core->getData()->actors.empty() && player.enabledItems[STREAMER_TYPE_ACTOR])
+						if (!core->getData()->actors.empty() && player.enabledItems[STREAMER_TYPE_ACTOR] && !sampgdk::IsPlayerNPC(player.playerID))
 						{
 							discoverActors(player, cells);
 						}

--- a/src/utility/geometry.cpp
+++ b/src/utility/geometry.cpp
@@ -240,7 +240,7 @@ void Utility::projectPoint(const Eigen::Vector3f &point, const Eigen::Vector4f &
 	matrix(2, 0) = 2 * ((quaternion[0] * quaternion[2]) - (quaternion[1] * quaternion[3]));
 	matrix(2, 1) = 2 * ((quaternion[1] * quaternion[2]) + (quaternion[0] * quaternion[3]));
 	matrix(2, 2) = 1 - 2 * ((quaternion[0] * quaternion[0]) + (quaternion[1] * quaternion[1]));
-	position[0] += -((point[2] * matrix(2, 0)) + (point[1] * matrix(2, 1)) + (point[0] * matrix(2, 2)));
+	position[0] += (point[2] * matrix(2, 0)) + (point[1] * matrix(2, 1)) + (point[0] * matrix(2, 2));
 	position[1] += -((point[2] * matrix(1, 0)) + (point[1] * matrix(1, 1)) + (point[0] * matrix(1, 2)));
 	position[2] += (point[2] * matrix(0, 0)) + (point[1] * matrix(0, 1)) + (point[0] * matrix(0, 2));
 }


### PR DESCRIPTION
Sorry for the bugs related to the object IDs, I produced them when I made that internal cleanup for reliability.

I checked the first commit and it looks like it fixes #193. Here's the code:
```C++
#include <a_samp>
#include <zcmd>
#include <sscanf2>
#include <streamer>

new lObject[ MAX_PLAYERS ] = 0;

CMD:atstage( playerid, params[ ] )
{
	new lStage = 0;
	if( sscanf( params, "d", lStage ) )
	    return SendClientMessage( playerid, -1, "/atstage [1 - Create | 2 - Attach | 3 - Edit Attach: Params: <0 data/1 attach, X, Y, Z, RX, RY, RZ> | 4 - Delete Object]" );

	switch( lStage )
	{
		case 1:
		{
			if( lObject[ playerid ] )
			{
			    DestroyDynamicObject( lObject[ playerid ] );
			    lObject[ playerid ] = 0;
			}

			new Float:X, Float:Y, Float:Z;
			GetPlayerPos( playerid, X, Y, Z );
			lObject[ playerid ] = CreateDynamicObject( 19522, X, Y + 5.0, Z, 0.0, 0.0, 0.0 );
		}

		case 2:
		{
			if( !lObject[ playerid ] )
			    return SendClientMessage( playerid, -1, "Object isn't spawned !" );

			AttachDynamicObjectToVehicle( lObject[ playerid ], GetPlayerVehicleID( playerid ), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 );
		}

		case 3:
		{
		    if( !lObject[ playerid ] )
			    return SendClientMessage( playerid, -1, "Object isn't spawned !" );

			new lType, Float:lPos[ 3 ], Float:lRot[ 3 ];
			if( sscanf( params, "P<, >{d}dffffff", lType, lPos[ 0 ], lPos[ 1 ], lPos[ 2 ], lRot[ 0 ], lRot[ 1 ], lRot[ 2 ] ) )
				return SendClientMessage( playerid, -1, "Incorrect parameters !" );

			if( lType == 0 )
			{
				Streamer_SetFloatData( STREAMER_TYPE_OBJECT, lObject[ playerid ], E_STREAMER_ATTACH_OFFSET_X, lPos[ 0 ] );
				Streamer_SetFloatData( STREAMER_TYPE_OBJECT, lObject[ playerid ], E_STREAMER_ATTACH_OFFSET_Y, lPos[ 1 ] );
				Streamer_SetFloatData( STREAMER_TYPE_OBJECT, lObject[ playerid ], E_STREAMER_ATTACH_OFFSET_Z, lPos[ 2 ] );
				Streamer_SetFloatData( STREAMER_TYPE_OBJECT, lObject[ playerid ], E_STREAMER_ATTACH_R_X, lRot[ 0 ] );
				Streamer_SetFloatData( STREAMER_TYPE_OBJECT, lObject[ playerid ], E_STREAMER_ATTACH_R_X, lRot[ 1 ] );
				Streamer_SetFloatData( STREAMER_TYPE_OBJECT, lObject[ playerid ], E_STREAMER_ATTACH_R_X, lRot[ 2 ] );
			}
			else
			{
			    AttachDynamicObjectToVehicle( lObject[ playerid ], GetPlayerVehicleID( playerid ), lPos[ 0 ], lPos[ 1 ], lPos[ 2 ], lRot[ 0 ], lRot[ 1 ], lRot[ 2 ] );
			}
		}

		case 4:
		{
			if( !lObject[ playerid ] )
				return SendClientMessage( playerid, -1, "Object isn't spawned !" );

			DestroyDynamicObject( lObject[ playerid ] );
			lObject[ playerid ] = 0;
		}

		default: SendClientMessage( playerid, -1, "Invalid stage !" );
	}

	return 1;
}
```

I tested the first commit for #202 and the objects remained attached after they were restreamed to me.