### PR TITLE
Is(Any)PlayerIn(Any)DynamicArea improvements

### DIFF
--- a/src/natives/areas.cpp
+++ b/src/natives/areas.cpp
@@ -253,10 +253,14 @@ cell AMX_NATIVE_CALL Natives::IsPlayerInDynamicArea(AMX *amx, cell *params)
 		}
 		else
 		{
-			boost::unordered_map<int, Item::SharedArea>::iterator a = core->getData()->areas.find(static_cast<int>(params[2]));
+			boost::unordered_map<int, Item::SharedArea>::const_iterator a = core->getData()->areas.find(static_cast<int>(params[2]));
 			if (a != core->getData()->areas.end())
 			{
-				return static_cast<cell>(Utility::isPointInArea(p->second.position, a->second)) != 0;
+				int state = sampgdk::GetPlayerState(p->second.playerID);
+				bool inArea = false;
+				boost::unordered_set<int>::iterator foundArea;
+				core->getStreamer()->processPlayerArea(p->second, a, state, inArea, foundArea);
+				return static_cast<cell>(inArea != 0);
 			}
 		}
 	}
@@ -279,9 +283,13 @@ cell AMX_NATIVE_CALL Natives::IsPlayerInAnyDynamicArea(AMX *amx, cell *params)
 		}
 		else
 		{
+			int state = sampgdk::GetPlayerState(p->second.playerID);
+			bool inArea = false;
+			boost::unordered_set<int>::iterator foundArea;
 			for (boost::unordered_map<int, Item::SharedArea>::const_iterator a = core->getData()->areas.begin(); a != core->getData()->areas.end(); ++a)
 			{
-				if (Utility::isPointInArea(p->second.position, a->second))
+				core->getStreamer()->processPlayerArea(p->second, a, state, inArea, foundArea);
+				if (inArea != 0)
 				{
 					return 1;
 				}
@@ -294,10 +302,10 @@ cell AMX_NATIVE_CALL Natives::IsPlayerInAnyDynamicArea(AMX *amx, cell *params)
 cell AMX_NATIVE_CALL Natives::IsAnyPlayerInDynamicArea(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(2, "IsAnyPlayerInDynamicArea");
-	for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
+	bool recheck = static_cast<int>(params[2]) != 0;
+	if (!recheck)
 	{
-		bool recheck = static_cast<int>(params[2]) != 0;
-		if (!recheck)
+		for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
 		{
 			boost::unordered_set<int>::iterator i = p->second.internalAreas.find(static_cast<int>(params[1]));
 			if (i != p->second.internalAreas.end())
@@ -305,12 +313,19 @@ cell AMX_NATIVE_CALL Natives::IsAnyPlayerInDynamicArea(AMX *amx, cell *params)
 				return 1;
 			}
 		}
-		else
+	}
+	else
+	{
+		bool inArea = false;
+		boost::unordered_set<int>::iterator foundArea;
+		boost::unordered_map<int, Item::SharedArea>::const_iterator a;
+		for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
 		{
-			boost::unordered_map<int, Item::SharedArea>::iterator a = core->getData()->areas.find(static_cast<int>(params[1]));
+			a = core->getData()->areas.find(static_cast<int>(params[1]));
 			if (a != core->getData()->areas.end())
 			{
-				return static_cast<cell>(Utility::isPointInArea(p->second.position, a->second)) != 0;
+				core->getStreamer()->processPlayerArea(p->second, a, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
+				return static_cast<cell>(inArea != 0);
 			}
 		}
 	}
@@ -320,21 +335,28 @@ cell AMX_NATIVE_CALL Natives::IsAnyPlayerInDynamicArea(AMX *amx, cell *params)
 cell AMX_NATIVE_CALL Natives::IsAnyPlayerInAnyDynamicArea(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(1, "IsAnyPlayerInAnyDynamicArea");
-	for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
+	bool recheck = static_cast<int>(params[1]) != 0;
+	if (!recheck)
 	{
-		bool recheck = static_cast<int>(params[1]) != 0;
-		if (!recheck)
+		for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
 		{
 			if (!p->second.internalAreas.empty())
 			{
 				return 1;
 			}
 		}
-		else
+	}
+	else
+	{
+		bool inArea = false;
+		boost::unordered_set<int>::iterator foundArea;
+		boost::unordered_map<int, Item::SharedArea>::const_iterator a;
+		for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
 		{
-			for (boost::unordered_map<int, Item::SharedArea>::const_iterator a = core->getData()->areas.begin(); a != core->getData()->areas.end(); ++a)
+			for (a = core->getData()->areas.begin(); a != core->getData()->areas.end(); ++a)
 			{
-				if (Utility::isPointInArea(p->second.position, a->second))
+				core->getStreamer()->processPlayerArea(p->second, a, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
+				if (inArea != 0)
 				{
 					return 1;
 				}

--- a/src/natives/areas.cpp
+++ b/src/natives/areas.cpp
@@ -259,7 +259,7 @@ cell AMX_NATIVE_CALL Natives::IsPlayerInDynamicArea(AMX *amx, cell *params)
 				int state = sampgdk::GetPlayerState(p->second.playerID);
 				bool inArea = false;
 				boost::unordered_set<int>::iterator foundArea;
-				core->getStreamer()->processPlayerArea(p->second, a, state, inArea, foundArea);
+				core->getStreamer()->processPlayerArea(p->second, a->second, state, inArea, foundArea);
 				return static_cast<cell>(inArea != 0);
 			}
 		}
@@ -288,7 +288,7 @@ cell AMX_NATIVE_CALL Natives::IsPlayerInAnyDynamicArea(AMX *amx, cell *params)
 			boost::unordered_set<int>::iterator foundArea;
 			for (boost::unordered_map<int, Item::SharedArea>::const_iterator a = core->getData()->areas.begin(); a != core->getData()->areas.end(); ++a)
 			{
-				core->getStreamer()->processPlayerArea(p->second, a, state, inArea, foundArea);
+				core->getStreamer()->processPlayerArea(p->second, a->second, state, inArea, foundArea);
 				if (inArea != 0)
 				{
 					return 1;
@@ -324,7 +324,7 @@ cell AMX_NATIVE_CALL Natives::IsAnyPlayerInDynamicArea(AMX *amx, cell *params)
 			a = core->getData()->areas.find(static_cast<int>(params[1]));
 			if (a != core->getData()->areas.end())
 			{
-				core->getStreamer()->processPlayerArea(p->second, a, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
+				core->getStreamer()->processPlayerArea(p->second, a->second, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
 				return static_cast<cell>(inArea != 0);
 			}
 		}
@@ -355,7 +355,7 @@ cell AMX_NATIVE_CALL Natives::IsAnyPlayerInAnyDynamicArea(AMX *amx, cell *params
 		{
 			for (a = core->getData()->areas.begin(); a != core->getData()->areas.end(); ++a)
 			{
-				core->getStreamer()->processPlayerArea(p->second, a, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
+				core->getStreamer()->processPlayerArea(p->second, a->second, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
 				if (inArea != 0)
 				{
 					return 1;

--- a/src/natives/areas.cpp
+++ b/src/natives/areas.cpp
@@ -256,11 +256,7 @@ cell AMX_NATIVE_CALL Natives::IsPlayerInDynamicArea(AMX *amx, cell *params)
 			boost::unordered_map<int, Item::SharedArea>::const_iterator a = core->getData()->areas.find(static_cast<int>(params[2]));
 			if (a != core->getData()->areas.end())
 			{
-				int state = sampgdk::GetPlayerState(p->second.playerID);
-				bool inArea = false;
-				boost::unordered_set<int>::iterator foundArea;
-				core->getStreamer()->processPlayerArea(p->second, a->second, state, inArea, foundArea);
-				return static_cast<cell>(inArea != 0);
+				return static_cast<cell>(core->getStreamer()->processPlayerArea(p->second, a->second, sampgdk::GetPlayerState(p->second.playerID)) != 0);
 			}
 		}
 	}
@@ -284,12 +280,9 @@ cell AMX_NATIVE_CALL Natives::IsPlayerInAnyDynamicArea(AMX *amx, cell *params)
 		else
 		{
 			int state = sampgdk::GetPlayerState(p->second.playerID);
-			bool inArea = false;
-			boost::unordered_set<int>::iterator foundArea;
 			for (boost::unordered_map<int, Item::SharedArea>::const_iterator a = core->getData()->areas.begin(); a != core->getData()->areas.end(); ++a)
 			{
-				core->getStreamer()->processPlayerArea(p->second, a->second, state, inArea, foundArea);
-				if (inArea != 0)
+				if (core->getStreamer()->processPlayerArea(p->second, a->second, state) != 0)
 				{
 					return 1;
 				}
@@ -316,16 +309,13 @@ cell AMX_NATIVE_CALL Natives::IsAnyPlayerInDynamicArea(AMX *amx, cell *params)
 	}
 	else
 	{
-		bool inArea = false;
-		boost::unordered_set<int>::iterator foundArea;
 		boost::unordered_map<int, Item::SharedArea>::const_iterator a;
 		for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
 		{
 			a = core->getData()->areas.find(static_cast<int>(params[1]));
 			if (a != core->getData()->areas.end())
 			{
-				core->getStreamer()->processPlayerArea(p->second, a->second, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
-				return static_cast<cell>(inArea != 0);
+				return static_cast<cell>(core->getStreamer()->processPlayerArea(p->second, a->second, sampgdk::GetPlayerState(p->second.playerID)) != 0);
 			}
 		}
 	}
@@ -348,15 +338,12 @@ cell AMX_NATIVE_CALL Natives::IsAnyPlayerInAnyDynamicArea(AMX *amx, cell *params
 	}
 	else
 	{
-		bool inArea = false;
-		boost::unordered_set<int>::iterator foundArea;
 		boost::unordered_map<int, Item::SharedArea>::const_iterator a;
 		for (boost::unordered_map<int, Player>::iterator p = core->getData()->players.begin(); p != core->getData()->players.end(); ++p)
 		{
 			for (a = core->getData()->areas.begin(); a != core->getData()->areas.end(); ++a)
 			{
-				core->getStreamer()->processPlayerArea(p->second, a->second, sampgdk::GetPlayerState(p->second.playerID), inArea, foundArea);
-				if (inArea != 0)
+				if (core->getStreamer()->processPlayerArea(p->second, a->second, sampgdk::GetPlayerState(p->second.playerID)) != 0)
 				{
 					return 1;
 				}

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -776,10 +776,13 @@ void Streamer::processAreas(Player &player, const std::vector<SharedCell> &cells
 
 bool Streamer::processPlayerArea(Player &player, boost::unordered_map<int, Item::SharedArea>::const_iterator &a, int state, bool &inArea, boost::unordered_set<int>::iterator &foundArea)
 {
-	inArea = false;
 	if (doesPlayerSatisfyConditions(a->second->players, player.playerID, a->second->interiors, player.interiorID, a->second->worlds, player.worldID) && ((!a->second->spectateMode && state != PLAYER_STATE_SPECTATING) || a->second->spectateMode))
 	{
 		inArea = Utility::isPointInArea(player.position, a->second);
+	}
+	else
+	{
+		inArea = false;
 	}
 	foundArea = player.internalAreas.find(a->first);
 	if (inArea)

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -769,30 +769,30 @@ void Streamer::processAreas(Player &player, const std::vector<SharedCell> &cells
 	{
 		for (boost::unordered_map<int, Item::SharedArea>::const_iterator a = (*c)->areas.begin(); a != (*c)->areas.end(); ++a)
 		{
-			Streamer::processPlayerArea(player, a, state, inArea, foundArea);
+			Streamer::processPlayerArea(player, a->second, state, inArea, foundArea);
 		}
 	}
 }
 
-bool Streamer::processPlayerArea(Player &player, boost::unordered_map<int, Item::SharedArea>::const_iterator &a, int state, bool &inArea, boost::unordered_set<int>::iterator &foundArea)
+void Streamer::processPlayerArea(Player &player, const Item::SharedArea &a, const int &state, bool &inArea, boost::unordered_set<int>::iterator &foundArea)
 {
-	if (doesPlayerSatisfyConditions(a->second->players, player.playerID, a->second->interiors, player.interiorID, a->second->worlds, player.worldID) && ((!a->second->spectateMode && state != PLAYER_STATE_SPECTATING) || a->second->spectateMode))
+	if (doesPlayerSatisfyConditions(a->players, player.playerID, a->interiors, player.interiorID, a->worlds, player.worldID) && ((!a->spectateMode && state != PLAYER_STATE_SPECTATING) || a->spectateMode))
 	{
-		inArea = Utility::isPointInArea(player.position, a->second);
+		inArea = Utility::isPointInArea(player.position, a);
 	}
 	else
 	{
 		inArea = false;
 	}
-	foundArea = player.internalAreas.find(a->first);
+	foundArea = player.internalAreas.find(a->areaID);
 	if (inArea)
 	{
 		if (foundArea == player.internalAreas.end())
 		{
-			player.internalAreas.insert(a->first);
-			areaEnterCallbacks.insert(std::make_pair(a->second->priority, boost::make_tuple(a->first, player.playerID)));
+			player.internalAreas.insert(a->areaID);
+			areaEnterCallbacks.insert(std::make_pair(a->priority, boost::make_tuple(a->areaID, player.playerID)));
 		}
-		if (a->second->cell)
+		if (a->cell)
 		{
 			player.visibleCell->areas.insert(*a);
 		}
@@ -802,10 +802,9 @@ bool Streamer::processPlayerArea(Player &player, boost::unordered_map<int, Item:
 		if (foundArea != player.internalAreas.end())
 		{
 			player.internalAreas.quick_erase(foundArea);
-			areaLeaveCallbacks.insert(std::make_pair(a->second->priority, boost::make_tuple(a->first, player.playerID)));
+			areaLeaveCallbacks.insert(std::make_pair(a->priority, boost::make_tuple(a->areaID, player.playerID)));
 		}
 	}
-	return inArea;
 }
 
 void Streamer::processCheckpoints(Player &player, const std::vector<SharedCell> &cells)

--- a/src/streamer.h
+++ b/src/streamer.h
@@ -78,7 +78,7 @@ private:
 
 	void processAreas(Player &player, const std::vector<SharedCell> &cells);
 public:
-	bool processPlayerArea(Player &player, boost::unordered_map<int, Item::SharedArea>::const_iterator &a, int state, bool &inArea, boost::unordered_set<int>::iterator &foundArea);
+	void processPlayerArea(Player &player, const Item::SharedArea &a, const int &state, bool &inArea, boost::unordered_set<int>::iterator &foundArea);
 private:
 	void processCheckpoints(Player &player, const std::vector<SharedCell> &cells);
 	void processRaceCheckpoints(Player &player, const std::vector<SharedCell> &cells);

--- a/src/streamer.h
+++ b/src/streamer.h
@@ -78,7 +78,7 @@ private:
 
 	void processAreas(Player &player, const std::vector<SharedCell> &cells);
 public:
-	void processPlayerArea(Player &player, const Item::SharedArea &a, const int &state, bool &inArea, boost::unordered_set<int>::iterator &foundArea);
+	bool processPlayerArea(Player &player, const Item::SharedArea &a, const int state);
 private:
 	void processCheckpoints(Player &player, const std::vector<SharedCell> &cells);
 	void processRaceCheckpoints(Player &player, const std::vector<SharedCell> &cells);

--- a/src/streamer.h
+++ b/src/streamer.h
@@ -77,6 +77,9 @@ private:
 	void streamActors();
 
 	void processAreas(Player &player, const std::vector<SharedCell> &cells);
+public:
+	bool processPlayerArea(Player &player, boost::unordered_map<int, Item::SharedArea>::const_iterator &a, int state, bool &inArea, boost::unordered_set<int>::iterator &foundArea);
+private:
 	void processCheckpoints(Player &player, const std::vector<SharedCell> &cells);
 	void processRaceCheckpoints(Player &player, const std::vector<SharedCell> &cells);
 


### PR DESCRIPTION
If the ```recheck``` parameter is set to 1:
- checks all area conditions (playerid, worldid, interior), just like a regular streaming iteration.
- if player's state in the specified area changed, the correct callback will be called at the next tick.

Fixes #227.

I tested it and it works good. (well, only for ```IsPlayerInDynamicArea``` and regular streaming, but I guess that the other functions should work fine too)

-----------

Sorry if I didn't create the ```processPlayerArea``` function in the right location and if I used too many parameters called by reference for your preference, but I also tried to improve the checking speed of areas, as they won't allocate and deallocate too much for every area (well, at least in my head, but I think that I actually managed to decrease the speed: I'm not sure if they are being allocated twice, I may confuse those pass-by-reference parameters with pointers, but some of the ones I passed by reference are actually pointers [::iterator, ::const_iterator]). Not sure if what I did makes any good difference, I'm pretty new in C++ and I didn't search too much about pointer arguments passed by reference - I guess that's what happens when you worked only in Pawn for a lot of time, C++ is a lot more powerful.

Please check it and try to make optimizations if possible (maybe all that pass by reference isn't needed).

I hope this code isn't looking retarded. :c

You can make a review and comment what should I change.