### PR TITLE
INVALID_STREAMER_ID instead of 0 and CreateDynamicPolygon(Ex) checks fixes

### DIFF
--- a/src/natives/actors.cpp
+++ b/src/natives/actors.cpp
@@ -32,7 +32,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicActor(AMX *amx, cell *params)
 	CHECK_PARAMS(13, "CreateDynamicActor");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_ACTOR) == core->getData()->actors.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int actorID = Item::Actor::identifier.get();
 	Item::SharedActor actor(new Item::Actor);

--- a/src/natives/areas.cpp
+++ b/src/natives/areas.cpp
@@ -36,7 +36,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCircle(AMX *amx, cell *params)
 	CHECK_PARAMS(7, "CreateDynamicCircle");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -60,7 +60,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCylinder(AMX *amx, cell *params)
 	CHECK_PARAMS(9, "CreateDynamicCylinder");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -85,7 +85,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicSphere(AMX *amx, cell *params)
 	CHECK_PARAMS(8, "CreateDynamicSphere");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -110,7 +110,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicRectangle(AMX *amx, cell *params)
 	CHECK_PARAMS(8, "CreateDynamicRectangle");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -136,7 +136,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCuboid(AMX *amx, cell *params)
 	CHECK_PARAMS(10, "CreateDynamicCuboid");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -162,12 +162,12 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicPolygon(AMX *amx, cell *params)
 	CHECK_PARAMS(8, "CreateDynamicPolygon");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	if (static_cast<int>(params[4] >= 2 && static_cast<int>(params[4]) % 2))
 	{
 		Utility::logError("CreateDynamicPolygon: Number of points must be divisible by two.");
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);

--- a/src/natives/areas.cpp
+++ b/src/natives/areas.cpp
@@ -164,9 +164,9 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicPolygon(AMX *amx, cell *params)
 	{
 		return INVALID_STREAMER_ID;
 	}
-	if (static_cast<int>(params[4] >= 2 && static_cast<int>(params[4]) % 2))
+	if (static_cast<int>(params[4]) < 6 || static_cast<int>(params[4]) % 2)
 	{
-		Utility::logError("CreateDynamicPolygon: Number of points must be divisible by two.");
+		Utility::logError("CreateDynamicPolygon: Number of points must be divisible by 2 and bigger or equal to 6.");
 		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();

--- a/src/natives/checkpoints.cpp
+++ b/src/natives/checkpoints.cpp
@@ -33,7 +33,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCP(AMX *amx, cell *params)
 	CHECK_PARAMS(10, "CreateDynamicCP");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_CP) == core->getData()->checkpoints.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int checkpointID = Item::Checkpoint::identifier.get();
 	Item::SharedCheckpoint checkpoint(new Item::Checkpoint);

--- a/src/natives/extended.cpp
+++ b/src/natives/extended.cpp
@@ -35,7 +35,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicObjectEx(AMX *amx, cell *params)
 	CHECK_PARAMS(18, "CreateDynamicObjectEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_OBJECT) == core->getData()->objects.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int objectID = Item::Object::identifier.get();
 	Item::SharedObject object(new Item::Object);
@@ -67,7 +67,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicPickupEx(AMX *amx, cell *params)
 	CHECK_PARAMS(15, "CreateDynamicPickupEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_PICKUP) == core->getData()->pickups.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int pickupID = Item::Pickup::identifier.get();
 	Item::SharedPickup pickup(new Item::Pickup);
@@ -97,7 +97,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCPEx(AMX *amx, cell *params)
 	CHECK_PARAMS(14, "CreateDynamicCPEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_CP) == core->getData()->checkpoints.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int checkpointID = Item::Checkpoint::identifier.get();
 	Item::SharedCheckpoint checkpoint(new Item::Checkpoint);
@@ -126,7 +126,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicRaceCPEx(AMX *amx, cell *params)
 	CHECK_PARAMS(18, "CreateDynamicRaceCPEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_RACE_CP) == core->getData()->raceCheckpoints.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int raceCheckpointID = Item::RaceCheckpoint::identifier.get();
 	Item::SharedRaceCheckpoint raceCheckpoint(new Item::RaceCheckpoint);
@@ -157,7 +157,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicMapIconEx(AMX *amx, cell *params)
 	CHECK_PARAMS(16, "CreateDynamicMapIconEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_MAP_ICON) == core->getData()->mapIcons.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int mapIconID = Item::MapIcon::identifier.get();
 	Item::SharedMapIcon mapIcon(new Item::MapIcon);
@@ -188,7 +188,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamic3DTextLabelEx(AMX *amx, cell *params)
 	CHECK_PARAMS(19, "CreateDynamic3DTextLabelEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_3D_TEXT_LABEL) == core->getData()->textLabels.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int textLabelID = Item::TextLabel::identifier.get();
 	Item::SharedTextLabel textLabel(new Item::TextLabel);
@@ -231,7 +231,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCircleEx(AMX *amx, cell *params)
 	CHECK_PARAMS(10, "CreateDynamicCircleEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -256,7 +256,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCylinderEx(AMX *amx, cell *params)
 	CHECK_PARAMS(12, "CreateDynamicCylinderEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -282,7 +282,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicSphereEx(AMX *amx, cell *params)
 	CHECK_PARAMS(11, "CreateDynamicSphereEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -307,7 +307,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicRectangleEx(AMX *amx, cell *params)
 	CHECK_PARAMS(11, "CreateDynamicRectangleEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -333,7 +333,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicCuboidEx(AMX *amx, cell *params)
 	CHECK_PARAMS(13, "CreateDynamicCuboidEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -359,11 +359,12 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicPolygonEx(AMX *amx, cell *params)
 	CHECK_PARAMS(11, "CreateDynamicPolygonEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_AREA) == core->getData()->areas.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	if (static_cast<int>(params[4] >= 2 && static_cast<int>(params[4]) % 2))
 	{
 		Utility::logError("CreateDynamicPolygonEx: Number of points must be divisible by two.");
+		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();
 	Item::SharedArea area(new Item::Area);
@@ -390,7 +391,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicActorEx(AMX *amx, cell *params)
 	CHECK_PARAMS(17, "CreateDynamicActorEx");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_ACTOR) == core->getData()->actors.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int actorID = Item::Actor::identifier.get();
 	Item::SharedActor actor(new Item::Actor);

--- a/src/natives/extended.cpp
+++ b/src/natives/extended.cpp
@@ -361,9 +361,9 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicPolygonEx(AMX *amx, cell *params)
 	{
 		return INVALID_STREAMER_ID;
 	}
-	if (static_cast<int>(params[4] >= 2 && static_cast<int>(params[4]) % 2))
+	if (static_cast<int>(params[4]) < 6 || static_cast<int>(params[4]) % 2)
 	{
-		Utility::logError("CreateDynamicPolygonEx: Number of points must be divisible by two.");
+		Utility::logError("CreateDynamicPolygonEx: Number of points must be divisible by 2 and bigger or equal to 6.");
 		return INVALID_STREAMER_ID;
 	}
 	int areaID = Item::Area::identifier.get();

--- a/src/natives/map-icons.cpp
+++ b/src/natives/map-icons.cpp
@@ -33,7 +33,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicMapIcon(AMX *amx, cell *params)
 	CHECK_PARAMS(12, "CreateDynamicMapIcon");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_MAP_ICON) == core->getData()->mapIcons.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int mapIconID = Item::MapIcon::identifier.get();
 	Item::SharedMapIcon mapIcon(new Item::MapIcon);

--- a/src/natives/objects.cpp
+++ b/src/natives/objects.cpp
@@ -37,7 +37,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicObject(AMX *amx, cell *params)
 	CHECK_PARAMS(14, "CreateDynamicObject");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_OBJECT) == core->getData()->objects.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int objectID = Item::Object::identifier.get();
 	Item::SharedObject object(new Item::Object);

--- a/src/natives/pickups.cpp
+++ b/src/natives/pickups.cpp
@@ -32,7 +32,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicPickup(AMX *amx, cell *params)
 	CHECK_PARAMS(11, "CreateDynamicPickup");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_PICKUP) == core->getData()->pickups.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int pickupID = Item::Pickup::identifier.get();
 	Item::SharedPickup pickup(new Item::Pickup);

--- a/src/natives/race-checkpoints.cpp
+++ b/src/natives/race-checkpoints.cpp
@@ -33,7 +33,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamicRaceCP(AMX *amx, cell *params)
 	CHECK_PARAMS(14, "CreateDynamicRaceCP");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_RACE_CP) == core->getData()->raceCheckpoints.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int raceCheckpointID = Item::RaceCheckpoint::identifier.get();
 	Item::SharedRaceCheckpoint raceCheckpoint(new Item::RaceCheckpoint);

--- a/src/natives/text-labels.cpp
+++ b/src/natives/text-labels.cpp
@@ -35,7 +35,7 @@ cell AMX_NATIVE_CALL Natives::CreateDynamic3DTextLabel(AMX *amx, cell *params)
 	CHECK_PARAMS(15, "CreateDynamic3DTextLabel");
 	if (core->getData()->getGlobalMaxItems(STREAMER_TYPE_3D_TEXT_LABEL) == core->getData()->textLabels.size())
 	{
-		return 0;
+		return INVALID_STREAMER_ID;
 	}
 	int textLabelID = Item::TextLabel::identifier.get();
 	Item::SharedTextLabel textLabel(new Item::TextLabel);


### PR DESCRIPTION
- Fixes a bug with CreateDynamicPolygonEx where an odd amount of coordinates could be given without stopping the function.

I changed `0` to `INVALID_STREAMER_ID` for consistency.

---------

Also, shouldn't
```cpp
if (static_cast<int>(params[4] >= 2 && static_cast<int>(params[4]) % 2))
{
    Utility::logError("CreateDynamicPolygon(Ex): Number of points must be divisible by two.");
    return INVALID_STREAMER_ID;
}
```
be more like
```cpp
if (params[4] < 4 || params[4] % 2)
{
    Utility::logError("CreateDynamicPolygon(Ex): Number of points must be divisible by two and bigger or equal to 4.");
    return INVALID_STREAMER_ID;
}
```
? Well, it should actually be "< 6" instead of "< 4", why would you create a line when it wouldn't have any effect ?