### PR TITLE
Fix for Streamer_GetDistanceToItem bug

### DIFF
--- a/src/natives/miscellaneous.cpp
+++ b/src/natives/miscellaneous.cpp
@@ -35,6 +35,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetDistanceToItem(AMX *amx, cell *params)
 	CHECK_PARAMS(7, "Streamer_GetDistanceToItem");
 	int dimensions = static_cast<int>(params[7]);
 	Eigen::Vector3f position = Eigen::Vector3f::Zero();
+	bool success = false;
 	switch (static_cast<int>(params[4]))
 	{
 		case STREAMER_TYPE_OBJECT:
@@ -137,8 +138,8 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetDistanceToItem(AMX *amx, cell *params)
 					}
 					case STREAMER_AREA_TYPE_SPHERE:
 					{
-
 						position = boost::get<Eigen::Vector3f>(areaPosition);
+						success = true;
 						break;
 					}
 					case STREAMER_AREA_TYPE_RECTANGLE:
@@ -163,6 +164,10 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetDistanceToItem(AMX *amx, cell *params)
 						return 1;
 					}
 				}
+			}
+			if (success)
+			{
+				break;
 			}
 			return 0;
 		}


### PR DESCRIPTION
The bug is that if your area type is `STREAMER_AREA_TYPE_SPHERE` then the function always returns 0.

This is because on [line 142](https://github.com/samp-incognito/samp-streamer-plugin/blob/4d3ab3b86c362cd376dccb10dd92be1446ccc07b/src/natives/miscellaneous.cpp#L142) you are only broken out of an inner switch statement, which ends at [line 166](https://github.com/samp-incognito/samp-streamer-plugin/blob/4d3ab3b86c362cd376dccb10dd92be1446ccc07b/src/natives/miscellaneous.cpp#L166), and has a `return 0;` after it.