### PR TITLE
Adds Streamer_(G/S)etItemPos

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,6 +116,8 @@ AMX_NATIVE_INFO natives[] =
 	{ "Streamer_CountItems", Natives::Streamer_CountItems },
 	{ "Streamer_GetNearbyItems", Natives::Streamer_GetNearbyItems },
 	{ "Streamer_GetAllVisibleItems", Natives::Streamer_GetAllVisibleItems },
+	{ "Streamer_GetItemPos", Natives::Streamer_GetItemPos },
+	{ "Streamer_SetItemPos", Natives::Streamer_SetItemPos },
 	{ "Streamer_GetItemOffset", Natives::Streamer_GetItemOffset },
 	{ "Streamer_SetItemOffset", Natives::Streamer_SetItemOffset },
 	// Objects

--- a/src/natives.h
+++ b/src/natives.h
@@ -107,6 +107,8 @@ namespace Natives
 	cell AMX_NATIVE_CALL Streamer_CountItems(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_GetNearbyItems(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_GetAllVisibleItems(AMX *amx, cell *params);
+	cell AMX_NATIVE_CALL Streamer_GetItemPos(AMX *amx, cell *params);
+	cell AMX_NATIVE_CALL Streamer_SetItemPos(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_GetItemOffset(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_SetItemOffset(AMX *amx, cell *params);
 	// Objects

--- a/src/natives/miscellaneous.cpp
+++ b/src/natives/miscellaneous.cpp
@@ -1896,7 +1896,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemPos(AMX *amx, cell *params)
 					{
 						position[0] = boost::get<Eigen::Vector2f>(areaPosition)[0];
 						position[1] = boost::get<Eigen::Vector2f>(areaPosition)[1];
-						if (a->second->height[0] == -INFINITY || a->second->height[1] == INFINITY)
+						if (a->second->height[0] == -std::numeric_limits<float>::infinity() || a->second->height[1] == std::numeric_limits<float>::infinity())
 						{
 							position[2] = 0.0f;
 						}
@@ -1933,7 +1933,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetItemPos(AMX *amx, cell *params)
 						Eigen::Vector2f centroid = boost::geometry::return_centroid<Eigen::Vector2f>(boost::get<Polygon2D>(areaPosition));
 						position[0] = centroid[0];
 						position[1] = centroid[1];
-						if (a->second->height[0] == -INFINITY || a->second->height[1] == INFINITY)
+						if (a->second->height[0] == -std::numeric_limits<float>::infinity() || a->second->height[1] == std::numeric_limits<float>::infinity())
 						{
 							position[2] = 0.0f;
 						}
@@ -2159,46 +2159,19 @@ cell AMX_NATIVE_CALL Natives::Streamer_SetItemPos(AMX *amx, cell *params)
 				{
 					case STREAMER_AREA_TYPE_CIRCLE:
 					{
-						a->second->position = Eigen::Vector2f(newpos.head<2>()); // Absolute
-						break;
-					}
-					case STREAMER_AREA_TYPE_CYLINDER:
-					{
-						a->second->height = Eigen::Vector2f(newpos[2], newpos[2]) + a->second->height; // Relative
-						a->second->position = Eigen::Vector2f(newpos.head<2>()); // Absolute
+						a->second->position = Eigen::Vector2f(newpos.head<2>());
 						break;
 					}
 					case STREAMER_AREA_TYPE_SPHERE:
 					{
-						a->second->position = newpos; // Absolute
+						a->second->position = newpos;
 						break;
 					}
-					case STREAMER_AREA_TYPE_RECTANGLE:
- 					{
- 						boost::get<Box2D>(a->second->position).min_corner() = newpos.head<2>() + boost::get<Box2D>(a->second->position).min_corner(); // Relative
- 						boost::get<Box2D>(a->second->position).max_corner() = newpos.head<2>() + boost::get<Box2D>(a->second->position).max_corner(); // Relative
- 						boost::geometry::correct(boost::get<Box2D>(a->second->position));
- 						break;
- 					}
-					case STREAMER_AREA_TYPE_CUBOID:
- 					{
- 						boost::get<Box3D>(a->second->position).min_corner() = newpos + boost::get<Box3D>(a->second->position).min_corner(); // Relative
- 						boost::get<Box3D>(a->second->position).max_corner() = newpos + boost::get<Box3D>(a->second->position).max_corner(); // Relative
- 						boost::geometry::correct(boost::get<Box3D>(a->second->position));
- 						break;
- 					}
- 					case STREAMER_AREA_TYPE_POLYGON:
- 					{
- 						a->second->height = newpos.head<2>() + a->second->height; // Relative
- 						std::vector<Eigen::Vector2f> points;
- 						for (std::vector<Eigen::Vector2f>::iterator p = boost::get<Polygon2D>(a->second->position).outer().begin(); p != boost::get<Polygon2D>(a->second->position).outer().end(); ++p)
- 						{
- 							points.push_back(newpos.head<2>() + Eigen::Vector2f(p->data()[0], p->data()[1])); // Relative
- 						}
- 						boost::geometry::assign_points(boost::get<Polygon2D>(a->second->position), points);
- 						boost::geometry::correct(boost::get<Polygon2D>(a->second->position));
- 						break;
- 					}
+					default:
+					{
+						Utility::logError("Streamer_SetItemPos: Invalid area type specified (only circles and spheres are supported).");
+						return 0;
+					}
 				}
 				core->getGrid()->removeArea(a->second, true);
 				return 1;

--- a/src/natives/miscellaneous.cpp
+++ b/src/natives/miscellaneous.cpp
@@ -120,7 +120,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_GetDistanceToItem(AMX *amx, cell *params)
 				boost::variant<Polygon2D, Box2D, Box3D, Eigen::Vector2f, Eigen::Vector3f> areaPosition;
 				if (a->second->attach)
 				{
-					areaPosition = a->second->position;
+					areaPosition = a->second->attach->position;
 				}
 				else
 				{

--- a/streamer.inc
+++ b/streamer.inc
@@ -252,6 +252,8 @@ native Streamer_DestroyAllItems(type, serverwide = 1);
 native Streamer_CountItems(type, serverwide = 1);
 native Streamer_GetNearbyItems(Float:x, Float:y, Float:z, type, STREAMER_ALL_TAGS items[], maxitems = sizeof items, Float:range = 300.0);
 native Streamer_GetAllVisibleItems(playerid, type, STREAMER_ALL_TAGS items[], maxitems = sizeof items);
+native Streamer_GetItemPos(type, STREAMER_ALL_TAGS id, &Float:x, &Float:y, &Float:z);
+native Streamer_SetItemPos(type, STREAMER_ALL_TAGS id, Float:x, Float:y, Float:z);
 native Streamer_GetItemOffset(type, STREAMER_ALL_TAGS id, &Float:x, &Float:y, &Float:z);
 native Streamer_SetItemOffset(type, STREAMER_ALL_TAGS id, Float:x, Float:y, Float:z);
 


### PR DESCRIPTION
Solves #241.

Problems for now ( things that may give some problems to users - https://github.com/samp-incognito/samp-streamer-plugin/commit/2002be907843cdbb28af8ecbca1d5f8077366b6a ):
- `Streamer_SetItemPos`: Few of them are relative to the old position (so basically this function changes sometimes into some kind of Streamer_SetItemXYMoveZ [cylinder] or even Streamer_MoveItemPos [rectangles, cuboids, polygons]). It would be ideal to keep everything as absolute, but I couldn't find any way. I looked at `Utility::constructAttachedArea` but those things are relative in there too. We can't really do those things without adding more parameters to the `Streamer_SetItemPos` function I guess.
- The returned Z for areas where minZ or maxZ are infinite may be bad, as I kept it as `0.0`. They may expect another value if the `minZ` is actually bigger than `0.0`. Maybe I should change the value to minZ if the minZ is not infinite but maxZ is and change the value to maxZ if the minZ is infinite (but these may look weird too). Maybe a `NaN` ? That may weird out them even more.