### PR TITLE
Solves 3 callbacks returns

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -208,6 +208,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerEditObject(int playerid, bool playerobjec
 					for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 					{
 						int amxIndex = 0;
+						cell amxRetVal = 0;
 						if (!amx_FindPublic(*a, "OnPlayerEditDynamicObject", &amxIndex))
 						{
 							amx_Push(*a, amx_ftoc(fRotZ));
@@ -219,10 +220,14 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerEditObject(int playerid, bool playerobjec
 							amx_Push(*a, static_cast<cell>(response));
 							amx_Push(*a, static_cast<cell>(objectid));
 							amx_Push(*a, static_cast<cell>(playerid));
-							amx_Exec(*a, NULL, amxIndex);
+							amx_Exec(*a, &amxRetVal, amxIndex);
+							if (amxRetVal)
+							{
+								break;
+							}
 						}
 					}
-					break;
+					return true;
 				}
 			}
 		}
@@ -245,6 +250,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerSelectObject(int playerid, int type, int 
 					for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 					{
 						int amxIndex = 0;
+						cell amxRetVal = 0;
 						if (!amx_FindPublic(*a, "OnPlayerSelectDynamicObject", &amxIndex))
 						{
 							amx_Push(*a, amx_ftoc(z));
@@ -253,10 +259,14 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerSelectObject(int playerid, int type, int 
 							amx_Push(*a, static_cast<cell>(modelid));
 							amx_Push(*a, static_cast<cell>(objectid));
 							amx_Push(*a, static_cast<cell>(playerid));
-							amx_Exec(*a, NULL, amxIndex);
+							amx_Exec(*a, &amxRetVal, amxIndex);
+							if (amxRetVal)
+							{
+								break;
+							}
 						}
 					}
-					break;
+					return true;
 				}
 			}
 		}
@@ -314,6 +324,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerGiveDamageActor(int playerid, int actorid
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
+				cell amxRetVal = 0;
 				if (!amx_FindPublic(*a, "OnPlayerGiveDamageDynamicActor", &amxIndex))
 				{
 					amx_Push(*a, static_cast<cell>(bodypart));
@@ -321,13 +332,17 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerGiveDamageActor(int playerid, int actorid
 					amx_Push(*a, amx_ftoc(amount));
 					amx_Push(*a, static_cast<cell>(actorid));
 					amx_Push(*a, static_cast<cell>(playerid));
-					amx_Exec(*a, NULL, amxIndex);
+					amx_Exec(*a, &amxRetVal, amxIndex);
+					if (amxRetVal)
+					{
+						break;
+					}
 				}
 			}
-			break;
+			return true;
 		}
 	}
-	return true;
+	return false;
 }
 
 PLUGIN_EXPORT bool PLUGIN_CALL OnActorStreamIn(int actorid, int forplayerid)

--- a/streamer.inc
+++ b/streamer.inc
@@ -355,7 +355,7 @@ native IsToggleDynAreaSpectateMode(STREAMER_TAG_AREA areaid);
 
 // Natives (Actors)
 
-native STREAMER_TAG_ACTOR CreateDynamicActor(modelid, Float:x, Float:y, Float:z, Float:r, invulnerable = 1, Float:health = 100.0, worldid = -1, interiorid = -1, playerid = -1, Float:streamdistance = STREAMER_ACTOR_SD, STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1, priority = 0);
+native STREAMER_TAG_ACTOR CreateDynamicActor(modelid, Float:x, Float:y, Float:z, Float:r, invulnerable = true, Float:health = 100.0, worldid = -1, interiorid = -1, playerid = -1, Float:streamdistance = STREAMER_ACTOR_SD, STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1, priority = 0);
 native DestroyDynamicActor(STREAMER_TAG_ACTOR actorid);
 native IsValidDynamicActor(STREAMER_TAG_ACTOR actorid);
 native IsDynamicActorStreamedIn(STREAMER_TAG_ACTOR actorid, forplayerid);
@@ -370,7 +370,7 @@ native GetDynamicActorPos(STREAMER_TAG_ACTOR actorid, &Float:x, &Float:y, &Float
 native SetDynamicActorPos(STREAMER_TAG_ACTOR actorid, Float:x, Float:y, Float:z);
 native GetDynamicActorHealth(STREAMER_TAG_ACTOR actorid, &Float:health);
 native SetDynamicActorHealth(STREAMER_TAG_ACTOR actorid, Float:health);
-native SetDynamicActorInvulnerable(STREAMER_TAG_ACTOR actorid, invulnerable = 1);
+native SetDynamicActorInvulnerable(STREAMER_TAG_ACTOR actorid, invulnerable = true);
 native IsDynamicActorInvulnerable(STREAMER_TAG_ACTOR actorid);
 native STREAMER_TAG_ACTOR GetPlayerTargetDynamicActor(playerid);
 native STREAMER_TAG_ACTOR GetPlayerCameraTargetDynActor(playerid);


### PR DESCRIPTION
- OnPlayerGiveDamageActor wasn't called anymore, even if the damaged actor wasn't dynamic. (solves this issue: http://forum.sa-mp.com/showpost.php?p=3960148&postcount=5699)
- OnPlayerEditObject and OnPlayerSelectObject were still called in scripts, even if the edited/selected object is dynamic. They will be called now only if they aren't dynamic.
- OnPlayerEditObject, OnPlayerSelectObject and OnPlayerGiveDamageActor now support return values, just like the default callbacks: returning 1 will prevent that **DYNAMIC** callback to be called in other scripts.

I made this behavior only to these callbacks because these are the only callbacks from `callbacks.cpp` that are documented on [wiki](http://wiki.sa-mp.com) to support return values to stop calling in other scripts.