### PR TITLE
Adds Streamer_GetArrayDataLength

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,6 +101,7 @@ AMX_NATIVE_INFO natives[] =
 	{ "Streamer_IsInArrayData", Natives::Streamer_IsInArrayData },
 	{ "Streamer_AppendArrayData", Natives::Streamer_AppendArrayData },
 	{ "Streamer_RemoveArrayData", Natives::Streamer_RemoveArrayData },
+	{ "Streamer_GetArrayDataLength", Natives::Streamer_GetArrayDataLength },
 	{ "Streamer_GetUpperBound", Natives::Streamer_GetUpperBound },
 	// Miscellaneous
 	{ "Streamer_GetDistanceToItem", Natives::Streamer_GetDistanceToItem },

--- a/src/manipulation/array.cpp
+++ b/src/manipulation/array.cpp
@@ -469,3 +469,91 @@ int Manipulation::removeArrayData(AMX *amx, cell *params)
 	}
 	return 0;
 }
+
+int Manipulation::getArrayDataLength(AMX *amx, cell *params)
+{
+	int error = -1, result = -1;
+	switch (static_cast<int>(params[1]))
+	{
+		case STREAMER_TYPE_OBJECT:
+		{
+			result = getArrayDataLengthForItem(core->getData()->objects, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+			break;
+		}
+		case STREAMER_TYPE_PICKUP:
+		{
+			result = getArrayDataLengthForItem(core->getData()->pickups, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+			break;
+		}
+		case STREAMER_TYPE_CP:
+		{
+			result = getArrayDataLengthForItem(core->getData()->checkpoints, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+			break;
+		}
+		case STREAMER_TYPE_RACE_CP:
+		{
+			result = getArrayDataLengthForItem(core->getData()->raceCheckpoints, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+			break;
+		}
+		case STREAMER_TYPE_MAP_ICON:
+		{
+			result = getArrayDataLengthForItem(core->getData()->mapIcons, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+			break;
+		}
+		case STREAMER_TYPE_3D_TEXT_LABEL:
+		{
+			result = getArrayDataLengthForItem(core->getData()->textLabels, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+			break;
+		}
+		case STREAMER_TYPE_AREA:
+		{
+			switch (static_cast<int>(params[3]))
+			{
+				case AreaID:
+				{
+					error = InvalidData;
+					break;
+				}
+				default:
+				{
+					result = getArrayDataLengthForItem(core->getData()->areas, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+					break;
+				}
+			}
+			break;
+		}
+		case STREAMER_TYPE_ACTOR:
+		{
+			result = getArrayDataLengthForItem(core->getData()->actors, static_cast<int>(params[2]), static_cast<int>(params[3]), error);
+			break;
+		}
+		default:
+		{
+			error = InvalidType;
+			break;
+		}
+	}
+	switch (error)
+	{
+		case InvalidData:
+		{
+			Utility::logError("Streamer_GetArrayDataLength: Invalid data specified.");
+			break;
+		}
+		case InvalidID:
+		{
+			Utility::logError("Streamer_GetArrayDataLength: Invalid ID specified.");
+			break;
+		}
+		case InvalidType:
+		{
+			Utility::logError("Streamer_GetArrayDataLength: Invalid type specified.");
+			break;
+		}
+		default:
+		{
+			return result;
+		}
+	}
+	return 0;
+}

--- a/src/manipulation/array.h
+++ b/src/manipulation/array.h
@@ -27,6 +27,7 @@ namespace Manipulation
 	int isInArrayData(AMX *amx, cell *params);
 	int appendArrayData(AMX *amx, cell *params);
 	int removeArrayData(AMX *amx, cell *params);
+	int getArrayDataLength(AMX *amx, cell *params);
 
 	template <typename T>
 	int getArrayDataForItem(T &container, AMX *amx, int id, int data, cell output, cell size, int &error)
@@ -220,6 +221,51 @@ namespace Manipulation
 				case WorldID:
 				{
 					return Utility::removeFromContainer(i->second->worlds, value) != 0;
+				}
+				default:
+				{
+					error = InvalidData;
+					break;
+				}
+			}
+		}
+		else
+		{
+			error = InvalidID;
+		}
+		return 0;
+	}
+
+	template <typename T>
+	int getArrayDataLengthForItem(T &container, int id, int data, int &error)
+	{
+		typename T::iterator i = container.find(id);
+		if (i != container.end())
+		{
+			switch (data)
+			{
+				case AreaID:
+				{
+					int size = static_cast<int>(i->second->areas.size());
+					return size ? size : -1;
+				}
+				case ExtraID:
+				{
+					return static_cast<int>(i->second->extras.size());
+				}
+				case InteriorID:
+				{
+					int size = static_cast<int>(i->second->interiors.size());
+					return size ? size : -1;
+				}
+				case PlayerID:
+				{
+					return static_cast<int>(i->second->players.count());
+				}
+				case WorldID:
+				{
+					int size = static_cast<int>(i->second->worlds.size());
+					return size ? size : -1;
 				}
 				default:
 				{

--- a/src/natives.h
+++ b/src/natives.h
@@ -92,6 +92,7 @@ namespace Natives
 	cell AMX_NATIVE_CALL Streamer_IsInArrayData(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_AppendArrayData(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_RemoveArrayData(AMX *amx, cell *params);
+	cell AMX_NATIVE_CALL Streamer_GetArrayDataLength(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_GetUpperBound(AMX *amx, cell *params);
 	// Miscellaneous
 	cell AMX_NATIVE_CALL Streamer_GetDistanceToItem(AMX *amx, cell *params);

--- a/src/natives/manipulation.cpp
+++ b/src/natives/manipulation.cpp
@@ -77,6 +77,12 @@ cell AMX_NATIVE_CALL Natives::Streamer_RemoveArrayData(AMX *amx, cell *params)
 	return static_cast<cell>(Manipulation::removeArrayData(amx, params));
 }
 
+cell AMX_NATIVE_CALL Natives::Streamer_GetArrayDataLength(AMX *amx, cell *params)
+{
+	CHECK_PARAMS(3, "Streamer_GetArrayDataLength");
+	return static_cast<cell>(Manipulation::getArrayDataLength(amx, params));
+}
+
 cell AMX_NATIVE_CALL Natives::Streamer_GetUpperBound(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(1, "Streamer_GetUpperBound");

--- a/streamer.inc
+++ b/streamer.inc
@@ -235,6 +235,7 @@ native Streamer_SetArrayData(type, STREAMER_ALL_TAGS id, data, const src[], maxs
 native Streamer_IsInArrayData(type, STREAMER_ALL_TAGS id, data, value);
 native Streamer_AppendArrayData(type, STREAMER_ALL_TAGS id, data, value);
 native Streamer_RemoveArrayData(type, STREAMER_ALL_TAGS id, data, value);
+native Streamer_GetArrayDataLength(type, STREAMER_ALL_TAGS id, data);
 native Streamer_GetUpperBound(type);
 
 // Natives (Miscellaneous)


### PR DESCRIPTION
Solves #251.

There's a special case for players, worlds and interiors: they return -1 if the size is 0 because that means that the item is visible in all of them, not in none, I hope that's ok. Also, an array length may be 0 for players and extras, but the callback also returns 0 if something is wrong, I hope that's ok too. Could be written in the documentation.

Oh, here are my tests:
```pawn
#include <a_samp>
#include <streamer>

public OnFilterScriptInit( )
{
	new lItemTypes[ STREAMER_MAX_TYPES ][ ] = { "Object", "Pickup", "CP", "RaceCP", "MapIcon", "TextLabel", "Area", "Actor" };
	new lItem = INVALID_STREAMER_ID;

	#define printDataLength(%0,%1,%2,%3,%4) printf("Data Length:%s:worlds=%d(exp:%d),ints=%d(%d),players=%d(%d),areas=%d(%d)",lItemTypes[%0],Streamer_GetArrayDataLength(%0,lItem,E_STREAMER_WORLD_ID),%1,Streamer_GetArrayDataLength(%0,lItem,E_STREAMER_INTERIOR_ID),%2,Streamer_GetArrayDataLength(%0,lItem,E_STREAMER_PLAYER_ID),%3,Streamer_GetArrayDataLength(%0,lItem,E_STREAMER_AREA_ID),%4)

	// Object
	lItem = CreateDynamicObjectEx( 1000, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 );
	printDataLength( STREAMER_TYPE_OBJECT, -1, -1, MAX_PLAYERS, -1 );
	printf( "Data Length:Object:extras=%d(exp:%d)", Streamer_GetArrayDataLength( STREAMER_TYPE_OBJECT, lItem, E_STREAMER_EXTRA_ID ), 0 );

	lItem = CreateDynamicObjectEx( 1000, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, .worlds = { 1, 4, 6, 2 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .areas = { 1, 5 } );
	printDataLength( STREAMER_TYPE_OBJECT, 4, 1, 3, 2 );

	lItem = CreateDynamicObjectEx( 1000, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_OBJECT, -1, 1, 3, -1 );

	lItem = CreateDynamicObjectEx( 1000, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, .worlds = { 1, 10, 100, 1000 }, .interiors = { -1 }, .players = { -1 }, .areas = { 6, 13, 19, 2847 }, .maxinteriors = 0, .maxplayers = 0 );
	printDataLength( STREAMER_TYPE_OBJECT, 4, -1, 0, 4 );

	lItem = CreateDynamicObjectEx( 1000, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 );
	Streamer_AppendArrayData( STREAMER_TYPE_OBJECT, lItem, E_STREAMER_EXTRA_ID, 1 );
	Streamer_AppendArrayData( STREAMER_TYPE_OBJECT, lItem, E_STREAMER_EXTRA_ID, 2 );
	Streamer_AppendArrayData( STREAMER_TYPE_OBJECT, lItem, E_STREAMER_EXTRA_ID, 3 );
	printf( "Data Length:%s:extras=%d(exp:%d)", lItemTypes[ STREAMER_TYPE_OBJECT ], Streamer_GetArrayDataLength( STREAMER_TYPE_OBJECT, lItem, E_STREAMER_EXTRA_ID ), 3 );

	// Pickup
	lItem = CreateDynamicPickupEx( 1000, 1, 0.0, 0.0, 0.0, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_PICKUP, -1, 1, 3, -1 );

	// CP
	lItem = CreateDynamicCPEx( 0.0, 0.0, 0.0, 1.0, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_CP, -1, 1, 3, -1 );

	// RaceCP
	lItem = CreateDynamicRaceCPEx( 1, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_RACE_CP, -1, 1, 3, -1 );

	// MapIcon
	lItem = CreateDynamicMapIconEx( 0.0, 0.0, 0.0, 1, 1, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_MAP_ICON, -1, 1, 3, -1 );

	// 3DTextLabel
	lItem = _:CreateDynamic3DTextLabelEx( "Test", 0, 0.0, 0.0, 0.0, 1.0, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_3D_TEXT_LABEL, -1, 1, 3, -1 );

	// Area
	lItem = CreateDynamicSphereEx( 0.0, 0.0, 0.0, 1.0, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_AREA, -1, 1, 3, cellmin );

	// Actor
	lItem = CreateDynamicActorEx( 0, 0.0, 0.0, 0.0, 0.0, .worlds = { 1 }, .interiors = { 1 }, .players = { 5, 1, 2 }, .maxworlds = 0 );
	printDataLength( STREAMER_TYPE_ACTOR, -1, 1, 3, -1 );
	return 1;
}
```
Output:
```
Data Length:Object:worlds=-1(exp:-1),ints=-1(-1),players=1000(1000),areas=-1(-1)
Data Length:Object:extras=0(exp:0)
Data Length:Object:worlds=4(exp:4),ints=1(1),players=3(3),areas=2(2)
Data Length:Object:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=-1(-1)
Data Length:Object:worlds=4(exp:4),ints=-1(-1),players=0(0),areas=4(4)
Data Length:Object:extras=3(exp:3)
Data Length:Pickup:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=-1(-1)
Data Length:CP:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=-1(-1)
Data Length:RaceCP:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=-1(-1)
Data Length:MapIcon:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=-1(-1)
Data Length:TextLabel:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=-1(-1)
*** Streamer Plugin: Streamer_GetArrayDataLength: Invalid data specified.
Data Length:Area:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=0(--)
Data Length:Actor:worlds=-1(exp:-1),ints=1(1),players=3(3),areas=-1(-1)
```