### PR TITLE
Added Streamer_AmxUnloadDestroyItems

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -45,6 +45,7 @@ public:
 	bool errorCallbackEnabled;
 
 	std::set<AMX*> interfaces;
+	std::set<AMX*> amxUnloadDestroyItems;
 
 	std::vector<int> destroyedActors;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,7 @@ AMX_NATIVE_INFO natives[] =
 	{ "Streamer_IsToggleItemCallbacks", Natives::Streamer_IsToggleItemCallbacks },
 	{ "Streamer_ToggleErrorCallback", Natives::Streamer_ToggleErrorCallback },
 	{ "Streamer_IsToggleErrorCallback", Natives::Streamer_IsToggleErrorCallback },
+	{ "Streamer_AmxUnloadDestroyItems", Natives::Streamer_AmxUnloadDestroyItems },
 	// Updates
 	{ "Streamer_ProcessActiveItems", Natives::Streamer_ProcessActiveItems },
 	{ "Streamer_ToggleIdleUpdate", Natives::Streamer_ToggleIdleUpdate },
@@ -271,13 +272,18 @@ AMX_NATIVE_INFO natives[] =
 PLUGIN_EXPORT int PLUGIN_CALL AmxLoad(AMX *amx)
 {
 	core->getData()->interfaces.insert(amx);
+	core->getData()->amxUnloadDestroyItems.insert(amx);
 	return Utility::checkInterfaceAndRegisterNatives(amx, natives);
 }
 
 PLUGIN_EXPORT int PLUGIN_CALL AmxUnload(AMX *amx)
 {
 	core->getData()->interfaces.erase(amx);
-	Utility::destroyAllItemsInInterface(amx);
+	if(core->getData()->amxUnloadDestroyItems.find(amx) != core->getData()->amxUnloadDestroyItems.end())
+	{
+		Utility::destroyAllItemsInInterface(amx);
+		core->getData()->amxUnloadDestroyItems.erase(amx);
+	}
 	return AMX_ERR_NONE;
 }
 

--- a/src/natives.h
+++ b/src/natives.h
@@ -71,6 +71,7 @@ namespace Natives
 	cell AMX_NATIVE_CALL Streamer_IsToggleItemCallbacks(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_ToggleErrorCallback(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_IsToggleErrorCallback(AMX *amx, cell *params);
+	cell AMX_NATIVE_CALL Streamer_AmxUnloadDestroyItems(AMX *amx, cell *params);
 	// Updates
 	cell AMX_NATIVE_CALL Streamer_ProcessActiveItems(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_ToggleIdleUpdate(AMX *amx, cell *params);

--- a/src/natives/settings.cpp
+++ b/src/natives/settings.cpp
@@ -772,6 +772,25 @@ cell AMX_NATIVE_CALL Natives::Streamer_ToggleErrorCallback(AMX *amx, cell *param
 
 cell AMX_NATIVE_CALL Natives::Streamer_IsToggleErrorCallback(AMX *amx, cell *params)
 {
-	CHECK_PARAMS(1, "Streamer_IsToggleErrorCallback");
 	return static_cast<cell>(core->getData()->errorCallbackEnabled != 0);
+}
+
+cell AMX_NATIVE_CALL Natives::Streamer_AmxUnloadDestroyItems(AMX *amx, cell *params)
+{
+	CHECK_PARAMS(1, "Streamer_AmxUnloadDestroyItems");
+	if(static_cast<int>(params[1]) != 0)
+	{
+		if(core->getData()->amxUnloadDestroyItems.find(amx) != core->getData()->amxUnloadDestroyItems.end())
+		{
+			return 0;
+		}
+		core->getData()->amxUnloadDestroyItems.insert(amx);
+		return 1;
+	}
+	if(core->getData()->amxUnloadDestroyItems.find(amx) == core->getData()->amxUnloadDestroyItems.end())
+	{
+		return 0;
+	}
+	core->getData()->amxUnloadDestroyItems.erase(amx);
+	return 1;
 }

--- a/streamer.inc
+++ b/streamer.inc
@@ -210,6 +210,7 @@ native Streamer_ToggleItemCallbacks(type, STREAMER_ALL_TAGS id, toggle);
 native Streamer_IsToggleItemCallbacks(type, STREAMER_ALL_TAGS id);
 native Streamer_ToggleErrorCallback(toggle);
 native Streamer_IsToggleErrorCallback();
+native Streamer_AmxUnloadDestroyItems(toggle);
 
 // Natives (Updates)
 


### PR DESCRIPTION
- Fixed bug where Streamer_IsToggleErrorCallback required one parameter.

Solves #254.

--------

`Streamer_AmxUnloadDestroyItems`

Default: toggled on.

Returns 1:
- If `toggle` is `true` and it was toggled off before
- If `toggle` is `false` and it was toggled on before

Returns 0:
- If `toggle` is `true` and it was toggled on before too
- If `toggle` is `false` and it was toggled off before too

Hopefully the name is ok, I couldn't think of anything better. Also, I didn't test this, but everything looks fine to me.

------

EDIT:
![image](https://user-images.githubusercontent.com/6208948/33531355-d29c7556-d894-11e7-834f-662d88c96e28.png)

I should think to keep the exact same name to the commit type. :laughing: You should commit with the name "Adds" I guess.