### PR TITLE
Fix shadowing and some small things

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -164,13 +164,13 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerPickUpPickup(int playerid, int pickupid)
 	{
 		if (i->second == pickupid)
 		{
-			int dynPickupid = i->first;
+			int dynPickupId = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
 				if (!amx_FindPublic(*a, "OnPlayerPickUpDynamicPickup", &amxIndex))
 				{
-					amx_Push(*a, static_cast<cell>(dynPickupid));
+					amx_Push(*a, static_cast<cell>(dynPickupId));
 					amx_Push(*a, static_cast<cell>(playerid));
 					amx_Exec(*a, NULL, amxIndex);
 				}
@@ -192,10 +192,10 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerEditObject(int playerid, bool playerobjec
 			{
 				if (i->second == objectid)
 				{
-					int dynObjectid = i->first;
+					int dynObjectId = i->first;
 					if (response == EDIT_RESPONSE_CANCEL || response == EDIT_RESPONSE_FINAL)
 					{
-						boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(dynObjectid);
+						boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(dynObjectId);
 						if (o != core->getData()->objects.end())
 						{
 							if (o->second->comparableStreamDistance < STREAMER_STATIC_DISTANCE_CUTOFF && o->second->originalComparableStreamDistance > STREAMER_STATIC_DISTANCE_CUTOFF)
@@ -218,7 +218,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerEditObject(int playerid, bool playerobjec
 							amx_Push(*a, amx_ftoc(fY));
 							amx_Push(*a, amx_ftoc(fX));
 							amx_Push(*a, static_cast<cell>(response));
-							amx_Push(*a, static_cast<cell>(dynObjectid));
+							amx_Push(*a, static_cast<cell>(dynObjectId));
 							amx_Push(*a, static_cast<cell>(playerid));
 							amx_Exec(*a, &amxRetVal, amxIndex);
 							if (amxRetVal)
@@ -246,7 +246,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerSelectObject(int playerid, int type, int 
 			{
 				if (i->second == objectid)
 				{
-					int dynObjectid = i->first;
+					int dynObjectId = i->first;
 					for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 					{
 						int amxIndex = 0;
@@ -257,7 +257,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerSelectObject(int playerid, int type, int 
 							amx_Push(*a, amx_ftoc(y));
 							amx_Push(*a, amx_ftoc(x));
 							amx_Push(*a, static_cast<cell>(modelid));
-							amx_Push(*a, static_cast<cell>(dynObjectid));
+							amx_Push(*a, static_cast<cell>(dynObjectId));
 							amx_Push(*a, static_cast<cell>(playerid));
 							amx_Exec(*a, &amxRetVal, amxIndex);
 							if (amxRetVal)
@@ -320,7 +320,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerGiveDamageActor(int playerid, int actorid
 	{
 		if (i->second == actorid)
 		{
-			int dynActorid = i->first;
+			int dynActorId = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
@@ -330,7 +330,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerGiveDamageActor(int playerid, int actorid
 					amx_Push(*a, static_cast<cell>(bodypart));
 					amx_Push(*a, static_cast<cell>(weaponid));
 					amx_Push(*a, amx_ftoc(amount));
-					amx_Push(*a, static_cast<cell>(dynActorid));
+					amx_Push(*a, static_cast<cell>(dynActorId));
 					amx_Push(*a, static_cast<cell>(playerid));
 					amx_Exec(*a, &amxRetVal, amxIndex);
 					if (amxRetVal)
@@ -351,14 +351,14 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnActorStreamIn(int actorid, int forplayerid)
 	{
 		if (i->second == actorid)
 		{
-			int dynActorid = i->first;
+			int dynActorId = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
 				if (!amx_FindPublic(*a, "OnDynamicActorStreamIn", &amxIndex))
 				{
 					amx_Push(*a, static_cast<cell>(forplayerid));
-					amx_Push(*a, static_cast<cell>(dynActorid));
+					amx_Push(*a, static_cast<cell>(dynActorId));
 					amx_Exec(*a, NULL, amxIndex);
 				}
 			}
@@ -374,14 +374,14 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnActorStreamOut(int actorid, int forplayerid)
 	{
 		if (i->second == actorid)
 		{
-			int dynActorid = i->first;
+			int dynActorId = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
 				if (!amx_FindPublic(*a, "OnDynamicActorStreamOut", &amxIndex))
 				{
 					amx_Push(*a, static_cast<cell>(forplayerid));
-					amx_Push(*a, static_cast<cell>(dynActorid));
+					amx_Push(*a, static_cast<cell>(dynActorId));
 					amx_Exec(*a, NULL, amxIndex);
 				}
 			}

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -164,13 +164,13 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerPickUpPickup(int playerid, int pickupid)
 	{
 		if (i->second == pickupid)
 		{
-			int pickupid = i->first;
+			int dynPickupid = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
 				if (!amx_FindPublic(*a, "OnPlayerPickUpDynamicPickup", &amxIndex))
 				{
-					amx_Push(*a, static_cast<cell>(pickupid));
+					amx_Push(*a, static_cast<cell>(dynPickupid));
 					amx_Push(*a, static_cast<cell>(playerid));
 					amx_Exec(*a, NULL, amxIndex);
 				}
@@ -192,10 +192,10 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerEditObject(int playerid, bool playerobjec
 			{
 				if (i->second == objectid)
 				{
-					int objectid = i->first;
+					int dynObjectid = i->first;
 					if (response == EDIT_RESPONSE_CANCEL || response == EDIT_RESPONSE_FINAL)
 					{
-						boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(objectid);
+						boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(dynObjectid);
 						if (o != core->getData()->objects.end())
 						{
 							if (o->second->comparableStreamDistance < STREAMER_STATIC_DISTANCE_CUTOFF && o->second->originalComparableStreamDistance > STREAMER_STATIC_DISTANCE_CUTOFF)
@@ -218,7 +218,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerEditObject(int playerid, bool playerobjec
 							amx_Push(*a, amx_ftoc(fY));
 							amx_Push(*a, amx_ftoc(fX));
 							amx_Push(*a, static_cast<cell>(response));
-							amx_Push(*a, static_cast<cell>(objectid));
+							amx_Push(*a, static_cast<cell>(dynObjectid));
 							amx_Push(*a, static_cast<cell>(playerid));
 							amx_Exec(*a, &amxRetVal, amxIndex);
 							if (amxRetVal)
@@ -246,7 +246,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerSelectObject(int playerid, int type, int 
 			{
 				if (i->second == objectid)
 				{
-					int objectid = i->first;
+					int dynObjectid = i->first;
 					for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 					{
 						int amxIndex = 0;
@@ -257,7 +257,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerSelectObject(int playerid, int type, int 
 							amx_Push(*a, amx_ftoc(y));
 							amx_Push(*a, amx_ftoc(x));
 							amx_Push(*a, static_cast<cell>(modelid));
-							amx_Push(*a, static_cast<cell>(objectid));
+							amx_Push(*a, static_cast<cell>(dynObjectid));
 							amx_Push(*a, static_cast<cell>(playerid));
 							amx_Exec(*a, &amxRetVal, amxIndex);
 							if (amxRetVal)
@@ -320,7 +320,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerGiveDamageActor(int playerid, int actorid
 	{
 		if (i->second == actorid)
 		{
-			int actorid = i->first;
+			int dynActorid = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
@@ -330,7 +330,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnPlayerGiveDamageActor(int playerid, int actorid
 					amx_Push(*a, static_cast<cell>(bodypart));
 					amx_Push(*a, static_cast<cell>(weaponid));
 					amx_Push(*a, amx_ftoc(amount));
-					amx_Push(*a, static_cast<cell>(actorid));
+					amx_Push(*a, static_cast<cell>(dynActorid));
 					amx_Push(*a, static_cast<cell>(playerid));
 					amx_Exec(*a, &amxRetVal, amxIndex);
 					if (amxRetVal)
@@ -351,14 +351,14 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnActorStreamIn(int actorid, int forplayerid)
 	{
 		if (i->second == actorid)
 		{
-			int actorid = i->first;
+			int dynActorid = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
 				if (!amx_FindPublic(*a, "OnDynamicActorStreamIn", &amxIndex))
 				{
 					amx_Push(*a, static_cast<cell>(forplayerid));
-					amx_Push(*a, static_cast<cell>(actorid));
+					amx_Push(*a, static_cast<cell>(dynActorid));
 					amx_Exec(*a, NULL, amxIndex);
 				}
 			}
@@ -374,14 +374,14 @@ PLUGIN_EXPORT bool PLUGIN_CALL OnActorStreamOut(int actorid, int forplayerid)
 	{
 		if (i->second == actorid)
 		{
-			int actorid = i->first;
+			int dynActorid = i->first;
 			for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
 			{
 				int amxIndex = 0;
 				if (!amx_FindPublic(*a, "OnDynamicActorStreamOut", &amxIndex))
 				{
 					amx_Push(*a, static_cast<cell>(forplayerid));
-					amx_Push(*a, static_cast<cell>(actorid));
+					amx_Push(*a, static_cast<cell>(dynActorid));
 					amx_Exec(*a, NULL, amxIndex);
 				}
 			}

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -19,4 +19,4 @@
 #include "common.h"
 
 Cell::Cell() : references(0) {}
-Cell::Cell(CellID cellID) : cellID(cellID), references(0) {}
+Cell::Cell(CellID cCellID) : cellID(cCellID), references(0) {}

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -19,4 +19,4 @@
 #include "common.h"
 
 Cell::Cell() : references(0) {}
-Cell::Cell(CellID cCellID) : cellID(cCellID), references(0) {}
+Cell::Cell(CellID passedCellId) : cellID(passedCellId), references(0) {}

--- a/src/chunk-streamer.cpp
+++ b/src/chunk-streamer.cpp
@@ -226,16 +226,16 @@ void ChunkStreamer::streamMapIcons(Player &player, bool automatic)
 					{
 						if (e->first.get<0>() < d->first.get<0>() || (e->first.get<1>() > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.get<1>() < e->first.get<1>()))
 						{
-							boost::unordered_map<int, int>::iterator i = player.internalMapIcons.find(e->second.get<0>());
-							if (i != player.internalMapIcons.end())
+							boost::unordered_map<int, int>::iterator ii = player.internalMapIcons.find(e->second.get<0>());
+							if (ii != player.internalMapIcons.end())
 							{
-								sampgdk::RemovePlayerMapIcon(player.playerID, i->second);
+								sampgdk::RemovePlayerMapIcon(player.playerID, ii->second);
 								if (e->second.get<1>()->streamCallbacks)
 								{
 									streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_MAP_ICON, e->second.get<0>()));
 								}
-								player.mapIconIdentifier.remove(i->second, player.internalMapIcons.size());
-								player.internalMapIcons.erase(i);
+								player.mapIconIdentifier.remove(ii->second, player.internalMapIcons.size());
+								player.internalMapIcons.erase(ii);
 							}
 							if (e->second.get<1>()->cell)
 							{
@@ -382,13 +382,13 @@ void ChunkStreamer::streamObjects(Player &player, bool automatic)
 				{
 					if (d->second.get<1>()->attach->object != INVALID_STREAMER_ID)
 					{
-						boost::unordered_map<int, int>::iterator i = player.internalObjects.find(d->second.get<1>()->attach->object);
-						if (i == player.internalObjects.end())
+						boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(d->second.get<1>()->attach->object);
+						if (ii == player.internalObjects.end())
 						{
 							d = player.discoveredObjects.left.erase(d);
 							continue;
 						}
-						internalBaseID = i->second;
+						internalBaseID = ii->second;
 					}
 				}
 				if (player.internalObjects.size() == player.currentVisibleObjects)
@@ -398,15 +398,15 @@ void ChunkStreamer::streamObjects(Player &player, bool automatic)
 					{
 						if (e->first.get<0>() < d->first.get<0>() || (e->first.get<1>() > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.get<1>() < e->first.get<1>()))
 						{
-							boost::unordered_map<int, int>::iterator i = player.internalObjects.find(e->second.get<0>());
-							if (i != player.internalObjects.end())
+							boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(e->second.get<0>());
+							if (ii != player.internalObjects.end())
 							{
-								sampgdk::DestroyPlayerObject(player.playerID, i->second);
+								sampgdk::DestroyPlayerObject(player.playerID, ii->second);
 								if (e->second.get<1>()->streamCallbacks)
 								{
 									streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_OBJECT, e->second.get<0>()));
 								}
-								player.internalObjects.erase(i);
+								player.internalObjects.erase(ii);
 							}
 							if (e->second.get<1>()->cell)
 							{
@@ -606,15 +606,15 @@ void ChunkStreamer::streamTextLabels(Player &player, bool automatic)
 					{
 						if (e->first.get<0>() < d->first.get<0>() || (e->first.get<1>() > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.get<1>() < e->first.get<1>()))
 						{
-							boost::unordered_map<int, int>::iterator i = player.internalTextLabels.find(e->second.get<0>());
-							if (i != player.internalTextLabels.end())
+							boost::unordered_map<int, int>::iterator ii = player.internalTextLabels.find(e->second.get<0>());
+							if (ii != player.internalTextLabels.end())
 							{
-								sampgdk::DeletePlayer3DTextLabel(player.playerID, i->second);
+								sampgdk::DeletePlayer3DTextLabel(player.playerID, ii->second);
 								if (e->second.get<1>()->streamCallbacks)
 								{
 									streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_3D_TEXT_LABEL, e->second.get<0>()));
 								}
-								player.internalTextLabels.erase(i);
+								player.internalTextLabels.erase(ii);
 							}
 							if (e->second.get<1>()->cell)
 							{

--- a/src/chunk-streamer.cpp
+++ b/src/chunk-streamer.cpp
@@ -226,16 +226,16 @@ void ChunkStreamer::streamMapIcons(Player &player, bool automatic)
 					{
 						if (e->first.get<0>() < d->first.get<0>() || (e->first.get<1>() > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.get<1>() < e->first.get<1>()))
 						{
-							boost::unordered_map<int, int>::iterator ii = player.internalMapIcons.find(e->second.get<0>());
-							if (ii != player.internalMapIcons.end())
+							boost::unordered_map<int, int>::iterator j = player.internalMapIcons.find(e->second.get<0>());
+							if (j != player.internalMapIcons.end())
 							{
-								sampgdk::RemovePlayerMapIcon(player.playerID, ii->second);
+								sampgdk::RemovePlayerMapIcon(player.playerID, j->second);
 								if (e->second.get<1>()->streamCallbacks)
 								{
 									streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_MAP_ICON, e->second.get<0>()));
 								}
-								player.mapIconIdentifier.remove(ii->second, player.internalMapIcons.size());
-								player.internalMapIcons.erase(ii);
+								player.mapIconIdentifier.remove(j->second, player.internalMapIcons.size());
+								player.internalMapIcons.erase(j);
 							}
 							if (e->second.get<1>()->cell)
 							{
@@ -382,13 +382,13 @@ void ChunkStreamer::streamObjects(Player &player, bool automatic)
 				{
 					if (d->second.get<1>()->attach->object != INVALID_STREAMER_ID)
 					{
-						boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(d->second.get<1>()->attach->object);
-						if (ii == player.internalObjects.end())
+						boost::unordered_map<int, int>::iterator j = player.internalObjects.find(d->second.get<1>()->attach->object);
+						if (j == player.internalObjects.end())
 						{
 							d = player.discoveredObjects.left.erase(d);
 							continue;
 						}
-						internalBaseID = ii->second;
+						internalBaseID = j->second;
 					}
 				}
 				if (player.internalObjects.size() == player.currentVisibleObjects)
@@ -398,15 +398,15 @@ void ChunkStreamer::streamObjects(Player &player, bool automatic)
 					{
 						if (e->first.get<0>() < d->first.get<0>() || (e->first.get<1>() > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.get<1>() < e->first.get<1>()))
 						{
-							boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(e->second.get<0>());
-							if (ii != player.internalObjects.end())
+							boost::unordered_map<int, int>::iterator j = player.internalObjects.find(e->second.get<0>());
+							if (j != player.internalObjects.end())
 							{
-								sampgdk::DestroyPlayerObject(player.playerID, ii->second);
+								sampgdk::DestroyPlayerObject(player.playerID, j->second);
 								if (e->second.get<1>()->streamCallbacks)
 								{
 									streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_OBJECT, e->second.get<0>()));
 								}
-								player.internalObjects.erase(ii);
+								player.internalObjects.erase(j);
 							}
 							if (e->second.get<1>()->cell)
 							{
@@ -606,15 +606,15 @@ void ChunkStreamer::streamTextLabels(Player &player, bool automatic)
 					{
 						if (e->first.get<0>() < d->first.get<0>() || (e->first.get<1>() > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.get<1>() < e->first.get<1>()))
 						{
-							boost::unordered_map<int, int>::iterator ii = player.internalTextLabels.find(e->second.get<0>());
-							if (ii != player.internalTextLabels.end())
+							boost::unordered_map<int, int>::iterator j = player.internalTextLabels.find(e->second.get<0>());
+							if (j != player.internalTextLabels.end())
 							{
-								sampgdk::DeletePlayer3DTextLabel(player.playerID, ii->second);
+								sampgdk::DeletePlayer3DTextLabel(player.playerID, j->second);
 								if (e->second.get<1>()->streamCallbacks)
 								{
 									streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_3D_TEXT_LABEL, e->second.get<0>()));
 								}
-								player.internalTextLabels.erase(ii);
+								player.internalTextLabels.erase(j);
 							}
 							if (e->second.get<1>()->cell)
 							{

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -575,8 +575,7 @@ CellID Grid::getCellID(const Eigen::Vector2f &position, bool insert)
 		boost::unordered_map<CellID, SharedCell>::iterator c = cells.find(cellID);
 		if (c == cells.end())
 		{
-			SharedCell cell(new Cell(cellID));
-			cells[cellID] = cell;
+			cells[cellID] = SharedCell(new Cell(cellID));
 		}
 	}
 	return cellID;

--- a/src/grid.h
+++ b/src/grid.h
@@ -90,11 +90,11 @@ private:
 		                     0.0f, cellSize, 0.0f, cellSize, 0.0f, cellSize * -1.0f, cellSize, cellSize * -1.0f, cellSize * -1.0f;
 	}
 
-	inline void eraseCellIfEmpty(const SharedCell &cell)
+	inline void eraseCellIfEmpty(const SharedCell &passedCell)
 	{
-		if (cell->areas.empty() && cell->checkpoints.empty() && cell->mapIcons.empty() && cell->objects.empty() && cell->pickups.empty() && cell->raceCheckpoints.empty() && cell->textLabels.empty() && cell->actors.empty())
+		if (passedCell->areas.empty() && passedCell->checkpoints.empty() && passedCell->mapIcons.empty() && passedCell->objects.empty() && passedCell->pickups.empty() && passedCell->raceCheckpoints.empty() && passedCell->textLabels.empty() && passedCell->actors.empty())
 		{
-			cells.erase(cell->cellID);
+			cells.erase(passedCell->cellID);
 		}
 	}
 

--- a/src/natives/objects.cpp
+++ b/src/natives/objects.cpp
@@ -343,10 +343,10 @@ cell AMX_NATIVE_CALL Natives::AttachCameraToDynamicObject(AMX *amx, cell *params
 cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(9, "AttachDynamicObjectToObject");
-	static AMX_NATIVE native = sampgdk::FindNative("SetPlayerGravity");
+	static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
 	if (native == NULL)
 	{
-		Utility::logError("AttachDynamicObjectToObject: YSF plugin must be loaded to attach objects to objects.");
+		Utility::logError("AttachDynamicObjectToObject: YSF plugin (a version having the AttachPlayerObjectToObject function) must be loaded to attach objects to objects.");
 		return 0;
 	}
 	boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(static_cast<int>(params[1]));
@@ -372,7 +372,6 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params
 				boost::unordered_map<int, int>::iterator j = p->second.internalObjects.find(o->second->attach->object);
 				if (j != p->second.internalObjects.end())
 				{
-					static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToObject");
 					if (native != NULL)
 					{
 						sampgdk::InvokeNative(native, "dddffffffb", p->first, i->second, j->second, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], o->second->attach->syncRotation);
@@ -422,10 +421,10 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToObject(AMX *amx, cell *params
 cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToPlayer(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(8, "AttachDynamicObjectToPlayer");
-	static AMX_NATIVE native = sampgdk::FindNative("SetPlayerGravity");
+	static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 	if (native == NULL)
 	{
-		Utility::logError("AttachDynamicObjectToPlayer: YSF plugin must be loaded to attach objects to players.");
+		Utility::logError("AttachDynamicObjectToObject: YSF plugin (a version having the AttachPlayerObjectToPlayer function) must be loaded to attach objects to objects.");
 		return 0;
 	}
 	boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(static_cast<int>(params[1]));
@@ -447,7 +446,6 @@ cell AMX_NATIVE_CALL Natives::AttachDynamicObjectToPlayer(AMX *amx, cell *params
 			boost::unordered_map<int, int>::iterator i = p->second.internalObjects.find(o->first);
 			if (i != p->second.internalObjects.end())
 			{
-				static AMX_NATIVE native = sampgdk::FindNative("AttachPlayerObjectToPlayer");
 				if (native != NULL)
 				{
 					sampgdk::InvokeNative(native, "dddffffffd", p->first, i->second, o->second->attach->player, o->second->attach->positionOffset[0], o->second->attach->positionOffset[1], o->second->attach->positionOffset[2], o->second->attach->rotation[0], o->second->attach->rotation[1], o->second->attach->rotation[2], 0);

--- a/src/natives/updates.cpp
+++ b/src/natives/updates.cpp
@@ -84,9 +84,9 @@ cell AMX_NATIVE_CALL Natives::Streamer_ToggleItemUpdate(AMX *amx, cell *params)
 	boost::unordered_map<int, Player>::iterator p = core->getData()->players.find(static_cast<int>(params[1]));
 	if (p != core->getData()->players.end())
 	{
-		if (static_cast<size_t>(params[2]) >= 0 && static_cast<size_t>(params[2]) < STREAMER_MAX_TYPES)
+		if (static_cast<int>(params[2]) >= 0 && static_cast<int>(params[2]) < STREAMER_MAX_TYPES)
 		{
-			p->second.enabledItems.set(static_cast<size_t>(params[2]), static_cast<int>(params[3]) != 0);
+			p->second.enabledItems.set(static_cast<int>(params[2]), params[3] != 0);
 			return 1;
 		}
 	}
@@ -99,7 +99,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_IsToggleItemUpdate(AMX *amx, cell *params
 	boost::unordered_map<int, Player>::iterator p = core->getData()->players.find(static_cast<int>(params[1]));
 	if (p != core->getData()->players.end())
 	{
-		if (static_cast<size_t>(params[2]) >= 0 && static_cast<size_t>(params[2]) < STREAMER_MAX_TYPES)
+		if (static_cast<int>(params[2]) >= 0 && static_cast<int>(params[2]) < STREAMER_MAX_TYPES)
 		{
 			return static_cast<cell>(p->second.enabledItems.test(params[2]) != 0);
 		}

--- a/src/natives/updates.cpp
+++ b/src/natives/updates.cpp
@@ -86,7 +86,7 @@ cell AMX_NATIVE_CALL Natives::Streamer_ToggleItemUpdate(AMX *amx, cell *params)
 	{
 		if (static_cast<int>(params[2]) >= 0 && static_cast<int>(params[2]) < STREAMER_MAX_TYPES)
 		{
-			p->second.enabledItems.set(static_cast<int>(params[2]), params[3] != 0);
+			p->second.enabledItems.set(static_cast<size_t>(params[2]), params[3] != 0);
 			return 1;
 		}
 	}

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -873,16 +873,16 @@ void Streamer::processMapIcons(Player &player, const std::vector<SharedCell> &ce
 			{
 				if (e->first.first < d->first.first || (e->first.second > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.second < e->first.second))
 				{
-					boost::unordered_map<int, int>::iterator i = player.internalMapIcons.find(e->second->mapIconID);
-					if (i != player.internalMapIcons.end())
+					boost::unordered_map<int, int>::iterator ii = player.internalMapIcons.find(e->second->mapIconID);
+					if (ii != player.internalMapIcons.end())
 					{
-						sampgdk::RemovePlayerMapIcon(player.playerID, i->second);
+						sampgdk::RemovePlayerMapIcon(player.playerID, ii->second);
 						if (e->second->streamCallbacks)
 						{
 							streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_MAP_ICON, e->second->mapIconID));
 						}
-						player.mapIconIdentifier.remove(i->second, player.internalMapIcons.size());
-						player.internalMapIcons.erase(i);
+						player.mapIconIdentifier.remove(ii->second, player.internalMapIcons.size());
+						player.internalMapIcons.erase(ii);
 					}
 					if (e->second->cell)
 					{
@@ -978,12 +978,12 @@ void Streamer::processObjects(Player &player, const std::vector<SharedCell> &cel
 		{
 			if (d->second->attach->object != INVALID_STREAMER_ID)
 			{
-				boost::unordered_map<int, int>::iterator i = player.internalObjects.find(d->second->attach->object);
-				if (i == player.internalObjects.end())
+				boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(d->second->attach->object);
+				if (ii == player.internalObjects.end())
 				{
 					continue;
 				}
-				internalBaseID = i->second;
+				internalBaseID = ii->second;
 			}
 		}
 		if (player.internalObjects.size() == player.currentVisibleObjects)
@@ -993,15 +993,15 @@ void Streamer::processObjects(Player &player, const std::vector<SharedCell> &cel
 			{
 				if (e->first.first < d->first.first || (e->first.second > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.second < e->first.second))
 				{
-					boost::unordered_map<int, int>::iterator i = player.internalObjects.find(e->second->objectID);
-					if (i != player.internalObjects.end())
+					boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(e->second->objectID);
+					if (ii != player.internalObjects.end())
 					{
-						sampgdk::DestroyPlayerObject(player.playerID, i->second);
+						sampgdk::DestroyPlayerObject(player.playerID, ii->second);
 						if (e->second->streamCallbacks)
 						{
 							streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_OBJECT, e->second->objectID));
 						}
-						player.internalObjects.erase(i);
+						player.internalObjects.erase(ii);
 					}
 					if (e->second->cell)
 					{
@@ -1288,15 +1288,15 @@ void Streamer::processTextLabels(Player &player, const std::vector<SharedCell> &
 			{
 				if (e->first.first < d->first.first || (e->first.second > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.second < e->first.second))
 				{
-					boost::unordered_map<int, int>::iterator i = player.internalTextLabels.find(e->second->textLabelID);
-					if (i != player.internalTextLabels.end())
+					boost::unordered_map<int, int>::iterator ii = player.internalTextLabels.find(e->second->textLabelID);
+					if (ii != player.internalTextLabels.end())
 					{
-						sampgdk::DeletePlayer3DTextLabel(player.playerID, i->second);
+						sampgdk::DeletePlayer3DTextLabel(player.playerID, ii->second);
 						if (e->second->streamCallbacks)
 						{
 							streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_3D_TEXT_LABEL, e->second->textLabelID));
 						}
-						player.internalTextLabels.erase(i);
+						player.internalTextLabels.erase(ii);
 					}
 					if (e->second->cell)
 					{

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -873,16 +873,16 @@ void Streamer::processMapIcons(Player &player, const std::vector<SharedCell> &ce
 			{
 				if (e->first.first < d->first.first || (e->first.second > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.second < e->first.second))
 				{
-					boost::unordered_map<int, int>::iterator ii = player.internalMapIcons.find(e->second->mapIconID);
-					if (ii != player.internalMapIcons.end())
+					boost::unordered_map<int, int>::iterator j = player.internalMapIcons.find(e->second->mapIconID);
+					if (j != player.internalMapIcons.end())
 					{
-						sampgdk::RemovePlayerMapIcon(player.playerID, ii->second);
+						sampgdk::RemovePlayerMapIcon(player.playerID, j->second);
 						if (e->second->streamCallbacks)
 						{
 							streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_MAP_ICON, e->second->mapIconID));
 						}
-						player.mapIconIdentifier.remove(ii->second, player.internalMapIcons.size());
-						player.internalMapIcons.erase(ii);
+						player.mapIconIdentifier.remove(j->second, player.internalMapIcons.size());
+						player.internalMapIcons.erase(j);
 					}
 					if (e->second->cell)
 					{
@@ -978,12 +978,12 @@ void Streamer::processObjects(Player &player, const std::vector<SharedCell> &cel
 		{
 			if (d->second->attach->object != INVALID_STREAMER_ID)
 			{
-				boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(d->second->attach->object);
-				if (ii == player.internalObjects.end())
+				boost::unordered_map<int, int>::iterator j = player.internalObjects.find(d->second->attach->object);
+				if (j == player.internalObjects.end())
 				{
 					continue;
 				}
-				internalBaseID = ii->second;
+				internalBaseID = j->second;
 			}
 		}
 		if (player.internalObjects.size() == player.currentVisibleObjects)
@@ -993,15 +993,15 @@ void Streamer::processObjects(Player &player, const std::vector<SharedCell> &cel
 			{
 				if (e->first.first < d->first.first || (e->first.second > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.second < e->first.second))
 				{
-					boost::unordered_map<int, int>::iterator ii = player.internalObjects.find(e->second->objectID);
-					if (ii != player.internalObjects.end())
+					boost::unordered_map<int, int>::iterator j = player.internalObjects.find(e->second->objectID);
+					if (j != player.internalObjects.end())
 					{
-						sampgdk::DestroyPlayerObject(player.playerID, ii->second);
+						sampgdk::DestroyPlayerObject(player.playerID, j->second);
 						if (e->second->streamCallbacks)
 						{
 							streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_OBJECT, e->second->objectID));
 						}
-						player.internalObjects.erase(ii);
+						player.internalObjects.erase(j);
 					}
 					if (e->second->cell)
 					{
@@ -1288,15 +1288,15 @@ void Streamer::processTextLabels(Player &player, const std::vector<SharedCell> &
 			{
 				if (e->first.first < d->first.first || (e->first.second > STREAMER_STATIC_DISTANCE_CUTOFF && d->first.second < e->first.second))
 				{
-					boost::unordered_map<int, int>::iterator ii = player.internalTextLabels.find(e->second->textLabelID);
-					if (ii != player.internalTextLabels.end())
+					boost::unordered_map<int, int>::iterator j = player.internalTextLabels.find(e->second->textLabelID);
+					if (j != player.internalTextLabels.end())
 					{
-						sampgdk::DeletePlayer3DTextLabel(player.playerID, ii->second);
+						sampgdk::DeletePlayer3DTextLabel(player.playerID, j->second);
 						if (e->second->streamCallbacks)
 						{
 							streamOutCallbacks.push_back(boost::make_tuple(STREAMER_TYPE_3D_TEXT_LABEL, e->second->textLabelID));
 						}
-						player.internalTextLabels.erase(ii);
+						player.internalTextLabels.erase(j);
 					}
 					if (e->second->cell)
 					{

--- a/src/utility/amx.cpp
+++ b/src/utility/amx.cpp
@@ -216,14 +216,14 @@ void Utility::executeFinalAreaCallbacks(int areaid)
 	}
 	for (std::vector<boost::tuple<int, int> >::const_iterator c = callbacks.begin(); c != callbacks.end(); ++c)
 	{
-		for (std::set<AMX*>::iterator a = core->getData()->interfaces.begin(); a != core->getData()->interfaces.end(); ++a)
+		for (std::set<AMX*>::iterator amx = core->getData()->interfaces.begin(); amx != core->getData()->interfaces.end(); ++amx)
 		{
 			int amxIndex = 0;
-			if (!amx_FindPublic(*a, "OnPlayerLeaveDynamicArea", &amxIndex))
+			if (!amx_FindPublic(*amx, "OnPlayerLeaveDynamicArea", &amxIndex))
 			{
-				amx_Push(*a, static_cast<cell>(c->get<0>()));
-				amx_Push(*a, static_cast<cell>(c->get<1>()));
-				amx_Exec(*a, NULL, amxIndex);
+				amx_Push(*amx, static_cast<cell>(c->get<0>()));
+				amx_Push(*amx, static_cast<cell>(c->get<1>()));
+				amx_Exec(*amx, NULL, amxIndex);
 			}
 		}
 	}


### PR DESCRIPTION
- Fix shadowing (well, I hope that I didn't miss to rename any of those important `i`s)
- Made checks for YSF a bit better in AttachDynamicObjectTo(Object/Player)
- Made checks for Streamer_ToggleItemUpdate a bit better

------------

I didn't modify the `premake5.lua` file because it looks like PreMake5 can't filter the C and C++ file too fine, so I receive warnings like these for C files:
```
cc1: warning: command line option ‘-Wctor-dtor-privacy’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-Wnoexcept’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-Wsign-promo’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-Wstrict-null-sentinel’ is valid for C++/ObjC++ but not for C
```
Also, because changing `includedirs { "include", "lib", "lib/**" }` to `sysincludedirs { "include", "lib", "lib/**" }` isn't suppressing warnings for the `sampgdk.cpp` file, probably because it gets added in this line: `files { "**.c", "**.cpp" }`. :man_shrugging:

But, well, I fixed every warning that was appearing in gmake after adding
```
buildoptions { "-Wextra", "-pedantic", "-Wconversion", "-Wcast-align", "-Wcast-qual", "-Wctor-dtor-privacy", "-Wdisabled-optimization", "-Wformat=2", "-Winit-self", "-Wlogical-op", "-Wmissing-include-dirs", "-Wnoexcept", "-Woverloaded-virtual", "-Wredundant-decls", "-Wshadow", "-Wsign-promo", "-Wstrict-null-sentinel", "-Wstrict-overflow=5", "-Wundef", "-Wno-unused", "-Wno-variadic-macros", "-Wno-parentheses", "-fdiagnostics-show-option" }
```

just for me, so that's fine I guess. I hope the naming of the renamed variables is ok for you.

I also tested the new `.dll` for this on Windows and it looks fine.