### PR TITLE
Allow playerobjects for NPCs

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -37,7 +37,10 @@ Player::Player(int id)
 	delayedRaceCheckpoint = 0;
 	delayedUpdate = false;
 	delayedUpdateType = 0;
-	enabledItems.set();
+	if (!sampgdk::IsPlayerNPC(id))
+	{
+		enabledItems.set();
+	}
 	interiorId = 0;
 	maxVisibleMapIcons = core->getData()->getGlobalMaxVisibleItems(STREAMER_TYPE_MAP_ICON);
 	maxVisibleObjects = core->getData()->getGlobalMaxVisibleItems(STREAMER_TYPE_OBJECT);

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -323,7 +323,7 @@ void Streamer::performPlayerUpdate(Player &player, bool automatic)
 					}
 					case STREAMER_TYPE_MAP_ICON:
 					{
-						if (!core->getData()->mapIcons.empty() && player.enabledItems[STREAMER_TYPE_MAP_ICON] && !sampgdk::IsPlayerNPC(player.playerId))
+						if (!core->getData()->mapIcons.empty() && player.enabledItems[STREAMER_TYPE_MAP_ICON])
 						{
 							if (core->getChunkStreamer()->getChunkStreamingEnabled())
 							{
@@ -338,7 +338,7 @@ void Streamer::performPlayerUpdate(Player &player, bool automatic)
 					}
 					case STREAMER_TYPE_3D_TEXT_LABEL:
 					{
-						if (!core->getData()->textLabels.empty() && player.enabledItems[STREAMER_TYPE_3D_TEXT_LABEL] && !sampgdk::IsPlayerNPC(player.playerId))
+						if (!core->getData()->textLabels.empty() && player.enabledItems[STREAMER_TYPE_3D_TEXT_LABEL])
 						{
 							if (core->getChunkStreamer()->getChunkStreamingEnabled())
 							{

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -292,7 +292,7 @@ void Streamer::performPlayerUpdate(Player &player, bool automatic)
 				{
 					case STREAMER_TYPE_OBJECT:
 					{
-						if (!core->getData()->objects.empty() && player.enabledItems[STREAMER_TYPE_OBJECT] && !sampgdk::IsPlayerNPC(player.playerId))
+						if (!core->getData()->objects.empty() && player.enabledItems[STREAMER_TYPE_OBJECT])
 						{
 							if (core->getChunkStreamer()->getChunkStreamingEnabled())
 							{


### PR DESCRIPTION
Allows the use of the following:
```
FCNPC_SetSurfingPlayerObject(npcid, Streamer_GetItemInternalID(npcid, STREAMER_TYPE_OBJECT, objectid));
```