### PR TITLE
Add custom array maps.

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -61,6 +61,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -106,6 +107,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -135,6 +137,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -166,6 +169,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -269,6 +273,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -299,6 +304,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -330,6 +336,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -378,6 +385,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
+		boost::unordered_map<int, std::vector<int>> extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;

--- a/src/item.h
+++ b/src/item.h
@@ -61,7 +61,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -107,7 +107,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -137,7 +137,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -169,7 +169,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -273,7 +273,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -304,7 +304,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -336,7 +336,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;
@@ -385,7 +385,7 @@ namespace Item
 
 		boost::unordered_set<int> areas;
 		std::vector<int> extras;
-		boost::unordered_map<int, std::vector<int>> extraExtras;
+		boost::unordered_map<int, std::vector<int> > extraExtras;
 		boost::unordered_set<int> interiors;
 		std::bitset<MAX_PLAYERS> players;
 		boost::unordered_set<int> worlds;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,11 +94,14 @@ AMX_NATIVE_INFO natives[] =
 	{ "Streamer_SetFloatData", Natives::Streamer_SetFloatData },
 	{ "Streamer_GetIntData", Natives::Streamer_GetIntData },
 	{ "Streamer_SetIntData", Natives::Streamer_SetIntData },
+	{ "Streamer_RemoveIntData", Natives::Streamer_RemoveIntData },
+	{ "Streamer_HasIntData", Natives::Streamer_HasIntData },
 	{ "Streamer_GetArrayData", Natives::Streamer_GetArrayData },
 	{ "Streamer_SetArrayData", Natives::Streamer_SetArrayData },
 	{ "Streamer_IsInArrayData", Natives::Streamer_IsInArrayData },
 	{ "Streamer_AppendArrayData", Natives::Streamer_AppendArrayData },
 	{ "Streamer_RemoveArrayData", Natives::Streamer_RemoveArrayData },
+	{ "Streamer_HasArrayData", Natives::Streamer_HasIntData }, // Alias.
 	{ "Streamer_GetArrayDataLength", Natives::Streamer_GetArrayDataLength },
 	{ "Streamer_GetUpperBound", Natives::Streamer_GetUpperBound },
 	// Miscellaneous

--- a/src/manipulation/array.h
+++ b/src/manipulation/array.h
@@ -59,6 +59,14 @@ namespace Manipulation
 				}
 				default:
 				{
+					if (data & 0x40000000)
+					{
+						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						if (p != i->second->extraExtras.end())
+						{
+							return Utility::convertContainerToArray(amx, output, size, p->second) != 0;
+						}
+					}
 					error = InvalidData;
 					break;
 				}
@@ -101,6 +109,11 @@ namespace Manipulation
 				}
 				default:
 				{
+					if (data & 0x40000000)
+					{
+						i->second->extraExtras[data & ~0xC0000000] = std::vector<int>();
+						return Utility::convertArrayToContainer(amx, input, size, i->second->extraExtras[data & ~0xC0000000]) != 0;
+					}
 					error = InvalidData;
 					return 0;
 				}
@@ -140,6 +153,14 @@ namespace Manipulation
 				}
 				default:
 				{
+					if (data & 0x40000000)
+					{
+						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						if (p != i->second->extraExtras.end())
+						{
+							return Utility::isInContainer(p->second, value) != 0;
+						}
+					}
 					error = InvalidData;
 					break;
 				}
@@ -182,6 +203,14 @@ namespace Manipulation
 				}
 				default:
 				{
+					if (data & 0x40000000)
+					{
+						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						if (p != i->second->extraExtras.end())
+						{
+							return Utility::addToContainer(p->second, value) != 0;
+						}
+					}
 					error = InvalidData;
 					break;
 				}
@@ -224,6 +253,14 @@ namespace Manipulation
 				}
 				default:
 				{
+					if (data & 0x40000000)
+					{
+						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						if (p != i->second->extraExtras.end())
+						{
+							return Utility::removeFromContainer(p->second, value) != 0;
+						}
+					}
 					error = InvalidData;
 					break;
 				}
@@ -269,6 +306,15 @@ namespace Manipulation
 				}
 				default:
 				{
+					if (data & 0x40000000)
+					{
+						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						if (p != i->second->extraExtras.end())
+						{
+							int size = static_cast<int>(p->second.size());
+							return size ? size : -1;
+						}
+					}
 					error = InvalidData;
 					break;
 				}

--- a/src/manipulation/array.h
+++ b/src/manipulation/array.h
@@ -61,7 +61,7 @@ namespace Manipulation
 				{
 					if (data & 0x40000000)
 					{
-						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						boost::unordered_map<int, std::vector<int> >::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
 						if (p != i->second->extraExtras.end())
 						{
 							return Utility::convertContainerToArray(amx, output, size, p->second) != 0;
@@ -155,7 +155,7 @@ namespace Manipulation
 				{
 					if (data & 0x40000000)
 					{
-						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						boost::unordered_map<int, std::vector<int> >::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
 						if (p != i->second->extraExtras.end())
 						{
 							return Utility::isInContainer(p->second, value) != 0;
@@ -205,7 +205,7 @@ namespace Manipulation
 				{
 					if (data & 0x40000000)
 					{
-						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						boost::unordered_map<int, std::vector<int> >::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
 						if (p != i->second->extraExtras.end())
 						{
 							return Utility::addToContainer(p->second, value) != 0;
@@ -255,7 +255,7 @@ namespace Manipulation
 				{
 					if (data & 0x40000000)
 					{
-						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						boost::unordered_map<int, std::vector<int> >::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
 						if (p != i->second->extraExtras.end())
 						{
 							return Utility::removeFromContainer(p->second, value) != 0;
@@ -308,7 +308,7 @@ namespace Manipulation
 				{
 					if (data & 0x40000000)
 					{
-						boost::unordered_map<int, std::vector<int>>::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
+						boost::unordered_map<int, std::vector<int> >::iterator p = i->second->extraExtras.find(data & ~0xC0000000);
 						if (p != i->second->extraExtras.end())
 						{
 							int size = static_cast<int>(p->second.size());

--- a/src/manipulation/int.cpp
+++ b/src/manipulation/int.cpp
@@ -97,6 +97,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::const_iterator p = o->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (p != o->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(p->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -149,6 +157,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::iterator x = p->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (x != p->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(x->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -193,6 +209,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::iterator p = c->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (p != c->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(p->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -241,6 +265,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::iterator p = r->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (p != r->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(p->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -297,6 +329,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::iterator p = m->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (p != m->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(p->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -365,6 +405,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::iterator p = t->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (p != t->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(p->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -433,6 +481,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::iterator p = a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (p != a->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(p->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -485,6 +541,14 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							boost::unordered_map<int, std::vector<int>>::iterator p = a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							if (p != a->second->extraExtras.end())
+							{
+								return Utility::getFirstValueInContainer(p->second);
+							}
+						}
 						error = InvalidData;
 						break;
 					}
@@ -517,6 +581,342 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 		case InvalidType:
 		{
 			Utility::logError("Streamer_GetIntData: Invalid type specified.");
+			break;
+		}
+	}
+	return 0;
+}
+
+int Manipulation::hasIntData(AMX *amx, cell *params)
+{
+	int error = -1;
+	switch (static_cast<int>(params[1]))
+	{
+		case STREAMER_TYPE_OBJECT:
+		{
+			boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(static_cast<int>(params[2]));
+			if (o != core->getData()->objects.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return o->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != o->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_PICKUP:
+		{
+			boost::unordered_map<int, Item::SharedPickup>::iterator p = core->getData()->pickups.find(static_cast<int>(params[2]));
+			if (p != core->getData()->pickups.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return p->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != p->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_CP:
+		{
+			boost::unordered_map<int, Item::SharedCheckpoint>::iterator c = core->getData()->checkpoints.find(static_cast<int>(params[2]));
+			if (c != core->getData()->checkpoints.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return c->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != c->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_RACE_CP:
+		{
+			boost::unordered_map<int, Item::SharedRaceCheckpoint>::iterator r = core->getData()->raceCheckpoints.find(static_cast<int>(params[2]));
+			if (r != core->getData()->raceCheckpoints.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return r->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != r->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_MAP_ICON:
+		{
+			boost::unordered_map<int, Item::SharedMapIcon>::iterator m = core->getData()->mapIcons.find(static_cast<int>(params[2]));
+			if (m != core->getData()->mapIcons.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return m->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != m->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_3D_TEXT_LABEL:
+		{
+			boost::unordered_map<int, Item::SharedTextLabel>::iterator t = core->getData()->textLabels.find(static_cast<int>(params[2]));
+			if (t != core->getData()->textLabels.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return t->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != t->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_AREA:
+		{
+			boost::unordered_map<int, Item::SharedArea>::iterator a = core->getData()->areas.find(static_cast<int>(params[2]));
+			if (a != core->getData()->areas.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != a->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_ACTOR:
+		{
+			boost::unordered_map<int, Item::SharedActor>::iterator a = core->getData()->actors.find(static_cast<int>(params[2]));
+			if (a != core->getData()->actors.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000) != a->second->extraExtras.end();
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		default:
+		{
+			error = InvalidType;
+			break;
+		}
+	}
+	switch (error)
+	{
+		case InvalidData:
+		{
+			Utility::logError("Streamer_Has(Int|Array)Data: Invalid data specified.");
+			break;
+		}
+		case InvalidId:
+		{
+			Utility::logError("Streamer_Has(Int|Array)Data: Invalid ID specified.");
+			break;
+		}
+		case InvalidType:
+		{
+			Utility::logError("Streamer_Has(Int|Array)Data: Invalid type specified.");
+			break;
+		}
+	}
+	return 0;
+}
+
+int Manipulation::removeIntData(AMX *amx, cell *params)
+{
+	int error = -1;
+	switch (static_cast<int>(params[1]))
+	{
+		case STREAMER_TYPE_OBJECT:
+		{
+			boost::unordered_map<int, Item::SharedObject>::iterator o = core->getData()->objects.find(static_cast<int>(params[2]));
+			if (o != core->getData()->objects.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return o->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_PICKUP:
+		{
+			boost::unordered_map<int, Item::SharedPickup>::iterator p = core->getData()->pickups.find(static_cast<int>(params[2]));
+			if (p != core->getData()->pickups.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return p->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_CP:
+		{
+			boost::unordered_map<int, Item::SharedCheckpoint>::iterator c = core->getData()->checkpoints.find(static_cast<int>(params[2]));
+			if (c != core->getData()->checkpoints.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return c->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_RACE_CP:
+		{
+			boost::unordered_map<int, Item::SharedRaceCheckpoint>::iterator r = core->getData()->raceCheckpoints.find(static_cast<int>(params[2]));
+			if (r != core->getData()->raceCheckpoints.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return r->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_MAP_ICON:
+		{
+			boost::unordered_map<int, Item::SharedMapIcon>::iterator m = core->getData()->mapIcons.find(static_cast<int>(params[2]));
+			if (m != core->getData()->mapIcons.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return m->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_3D_TEXT_LABEL:
+		{
+			boost::unordered_map<int, Item::SharedTextLabel>::iterator t = core->getData()->textLabels.find(static_cast<int>(params[2]));
+			if (t != core->getData()->textLabels.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return t->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_AREA:
+		{
+			boost::unordered_map<int, Item::SharedArea>::iterator a = core->getData()->areas.find(static_cast<int>(params[2]));
+			if (a != core->getData()->areas.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return a->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		case STREAMER_TYPE_ACTOR:
+		{
+			boost::unordered_map<int, Item::SharedActor>::iterator a = core->getData()->actors.find(static_cast<int>(params[2]));
+			if (a != core->getData()->actors.end())
+			{
+				if (static_cast<int>(params[3]) & 0x40000000)
+				{
+					return a->second->extraExtras.erase(static_cast<int>(params[3]) & ~0xC0000000);
+				}
+				error = InvalidData;
+			}
+			else
+			{
+				error = InvalidId;
+			}
+			break;
+		}
+		default:
+		{
+			error = InvalidType;
+			break;
+		}
+	}
+	switch (error)
+	{
+		case InvalidData:
+		{
+			Utility::logError("Streamer_RemoveIntData: Invalid data specified.");
+			break;
+		}
+		case InvalidId:
+		{
+			Utility::logError("Streamer_RemoveIntData: Invalid ID specified.");
+			break;
+		}
+		case InvalidType:
+		{
+			Utility::logError("Streamer_RemoveIntData: Invalid type specified.");
 			break;
 		}
 	}
@@ -693,6 +1093,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							o->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}
@@ -809,6 +1214,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							p->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}
@@ -867,6 +1277,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							c->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}
@@ -918,6 +1333,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							r->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}
@@ -993,6 +1413,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							m->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}
@@ -1113,6 +1538,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							t->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}
@@ -1233,6 +1663,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							a->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}
@@ -1290,6 +1725,11 @@ int Manipulation::setIntData(AMX *amx, cell *params)
 					}
 					default:
 					{
+						if (static_cast<int>(params[3]) & 0x40000000)
+						{
+							a->second->extraExtras[static_cast<int>(params[3]) & ~0xC0000000] = std::vector<int>(1, static_cast<int>(params[4]));
+							break;
+						}
 						error = InvalidData;
 						break;
 					}

--- a/src/manipulation/int.cpp
+++ b/src/manipulation/int.cpp
@@ -99,7 +99,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::const_iterator p = o->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::const_iterator p = o->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (p != o->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(p->second);
@@ -159,7 +159,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::iterator x = p->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::iterator x = p->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (x != p->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(x->second);
@@ -211,7 +211,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::iterator p = c->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::iterator p = c->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (p != c->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(p->second);
@@ -267,7 +267,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::iterator p = r->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::iterator p = r->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (p != r->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(p->second);
@@ -331,7 +331,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::iterator p = m->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::iterator p = m->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (p != m->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(p->second);
@@ -407,7 +407,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::iterator p = t->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::iterator p = t->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (p != t->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(p->second);
@@ -483,7 +483,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::iterator p = a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::iterator p = a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (p != a->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(p->second);
@@ -543,7 +543,7 @@ int Manipulation::getIntData(AMX *amx, cell *params)
 					{
 						if (static_cast<int>(params[3]) & 0x40000000)
 						{
-							boost::unordered_map<int, std::vector<int>>::iterator p = a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
+							boost::unordered_map<int, std::vector<int> >::iterator p = a->second->extraExtras.find(static_cast<int>(params[3]) & ~0xC0000000);
 							if (p != a->second->extraExtras.end())
 							{
 								return Utility::getFirstValueInContainer(p->second);

--- a/src/manipulation/int.h
+++ b/src/manipulation/int.h
@@ -23,6 +23,8 @@ namespace Manipulation
 {
 	int getIntData(AMX *amx, cell *params);
 	int setIntData(AMX *amx, cell *params);
+	int removeIntData(AMX *amx, cell *params);
+	int hasIntData(AMX *amx, cell *params);
 }
 
 #endif

--- a/src/natives.h
+++ b/src/natives.h
@@ -76,6 +76,8 @@ namespace Natives
 	cell AMX_NATIVE_CALL Streamer_SetFloatData(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_GetIntData(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_SetIntData(AMX *amx, cell *params);
+	cell AMX_NATIVE_CALL Streamer_RemoveIntData(AMX *amx, cell *params);
+	cell AMX_NATIVE_CALL Streamer_HasIntData(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_GetArrayData(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_SetArrayData(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL Streamer_IsInArrayData(AMX *amx, cell *params);

--- a/src/natives/manipulation.cpp
+++ b/src/natives/manipulation.cpp
@@ -44,6 +44,18 @@ cell AMX_NATIVE_CALL Natives::Streamer_SetIntData(AMX *amx, cell *params)
 	return static_cast<cell>(Manipulation::setIntData(amx, params));
 }
 
+cell AMX_NATIVE_CALL Natives::Streamer_RemoveIntData(AMX *amx, cell *params)
+{
+	CHECK_PARAMS(4);
+	return static_cast<cell>(Manipulation::removeIntData(amx, params));
+}
+
+cell AMX_NATIVE_CALL Natives::Streamer_HasIntData(AMX *amx, cell *params)
+{
+	CHECK_PARAMS(4);
+	return static_cast<cell>(Manipulation::hasIntData(amx, params));
+}
+
 cell AMX_NATIVE_CALL Natives::Streamer_GetArrayData(AMX *amx, cell *params)
 {
 	CHECK_PARAMS(5);

--- a/streamer.inc
+++ b/streamer.inc
@@ -178,6 +178,8 @@ enum
 	E_STREAMER_Z
 }
 
+#define E_STREAMER_CUSTOM(%0) ((%0) | 0x40000000 & ~0x80000000)
+
 // Natives (Settings)
 
 native Streamer_GetTickRate();
@@ -231,11 +233,14 @@ native Streamer_GetFloatData(type, STREAMER_ALL_TAGS:id, data, &Float:result);
 native Streamer_SetFloatData(type, STREAMER_ALL_TAGS:id, data, Float:value);
 native Streamer_GetIntData(type, STREAMER_ALL_TAGS:id, data);
 native Streamer_SetIntData(type, STREAMER_ALL_TAGS:id, data, value);
+native Streamer_RemoveIntData(type, STREAMER_ALL_TAGS:id, data);
+native Streamer_HasIntData(type, STREAMER_ALL_TAGS:id, data);
 native Streamer_GetArrayData(type, STREAMER_ALL_TAGS:id, data, dest[], maxdest = sizeof dest);
 native Streamer_SetArrayData(type, STREAMER_ALL_TAGS:id, data, const src[], maxsrc = sizeof src);
 native Streamer_IsInArrayData(type, STREAMER_ALL_TAGS:id, data, value);
 native Streamer_AppendArrayData(type, STREAMER_ALL_TAGS:id, data, value);
 native Streamer_RemoveArrayData(type, STREAMER_ALL_TAGS:id, data, value);
+native Streamer_HasArrayData(type, STREAMER_ALL_TAGS:id, data);
 native Streamer_GetArrayDataLength(type, STREAMER_ALL_TAGS:id, data);
 native Streamer_GetUpperBound(type);
 


### PR DESCRIPTION
I've never liked that there was only one "custom" data slot available for streamer items - it becomes almost impossible to use for library writers because they can't guarantee that other libraries or user code won't clobber their stored values.  I have to use a different method entirely when adding streamer y_inline callback support.  So this adds (almost) unlimited custom int/array IDs for `Streamer_SetIntData`.  It also adds `Streamer_HasIntData` and `Streamer_RemoveIntData` to remove only these custom data IDs (so you can't, for example, remove the VW entirely).

Example:

```pawn
Streamer_SetIntData(STREAMER_TYPE_OBJECT, objectid, E_STREAMER_CUSTOM(100), 55);
```

This way, any library can just use a random (hopefully unique) `E_STREAMER_CUSTOM` ID for storing their data along-side the streamer items.