### PR TITLE
Fix params check for Streamer_(Has/Remove)IntData

### DIFF
--- a/src/natives/manipulation.cpp
+++ b/src/natives/manipulation.cpp
@@ -46,13 +46,13 @@ cell AMX_NATIVE_CALL Natives::Streamer_SetIntData(AMX *amx, cell *params)
 
 cell AMX_NATIVE_CALL Natives::Streamer_RemoveIntData(AMX *amx, cell *params)
 {
-	CHECK_PARAMS(4);
+	CHECK_PARAMS(3);
 	return static_cast<cell>(Manipulation::removeIntData(amx, params));
 }
 
 cell AMX_NATIVE_CALL Natives::Streamer_HasIntData(AMX *amx, cell *params)
 {
-	CHECK_PARAMS(4);
+	CHECK_PARAMS(3);
 	return static_cast<cell>(Manipulation::hasIntData(amx, params));
 }
 


### PR DESCRIPTION
There are errors when you are trying to use these two functions:

```
[04:05:14] *** Streamer Plugin: Streamer_HasIntData: Expecting 4 parameter(s), but found 3.
[04:05:14] *** Streamer Plugin: Streamer_RemoveIntData: Expecting 4 parameter(s), but found 3.
```
